### PR TITLE
Refine technical design guidance with compact traceability and diagrams

### DIFF
--- a/.agents/skills/technical-design-manager/SKILL.md
+++ b/.agents/skills/technical-design-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: technical-design-manager
-description: Maintain long-lived domain technical design documents from governing SRS, architecture, ADRs, roadmap, research/proposals, executable contracts, Spec Kit artifacts, and source implementation evidence. Use when Codex needs to update or review TECHNICAL_DESIGN.md, sync implementation or specs to technical design, focus design changes on a specific module/component/section, produce technical-design impact maps, or run current-vs-target consistency review.
+description: Maintain long-lived domain technical design documents from governing SRS, architecture, ADRs, roadmap, research/proposals, executable contracts, Spec Kit artifacts, source implementation evidence, and tests. Use when Codex needs to update or review TECHNICAL_DESIGN.md, sync implementation or specs to technical design, focus design changes on a specific module/component/section, produce compact linked technical-design impact maps, prefer diagrams/tables over verbose prose, or run current-vs-target consistency review.
 ---
 
 # Technical Design Manager
@@ -9,7 +9,7 @@ description: Maintain long-lived domain technical design documents from governin
 
 Use this skill to maintain technical design documents as realization authority. The workflow consolidates governing documents, verified specs, and source implementation evidence into focused technical-design updates without turning the design doc into an SRS, ADR, roadmap, contract, or delivery task list.
 
-For reusable tables and checklists, read `references/technical-design-workflow.md` when the task asks for an impact map, implementation/spec synchronization, module/component review, consistency review, validation commands, or final update report.
+For reusable tables and checklists, read `references/technical-design-workflow.md` when the task asks for an impact map, compact cross-references, diagram/table guidance, implementation/spec synchronization, module/component review, consistency review, validation commands, or final update report.
 
 ## Operating Rules
 
@@ -20,6 +20,10 @@ For reusable tables and checklists, read `references/technical-design-workflow.m
 - Inspect governing artifacts before editing: SRS, architecture design, ADRs, roadmap, relevant specs, executable contracts, and source implementation evidence.
 - Read only relevant sections after heading or search inspection unless full-document context is needed.
 - Always produce a visible impact map before mutating long-lived technical design unless the user already supplied an equivalent map.
+- Use stable repository-relative links for important SRS, architecture, ADR, spec, contract, `src/`, and test references.
+- Link once per meaningful design claim or compact reference block; avoid repeating the same link in adjacent prose.
+- Prefer Mermaid diagrams, compact matrices, and short responsibility tables over long narrative when they communicate the design more clearly.
+- Keep generated technical-design content compact, semantic, and useful. Remove redundant background and avoid restating authority documents.
 - Report required follow-ups for `src/`, `specs/`, SRS, architecture, ADRs, roadmap, contracts, or traceability instead of editing them, unless the user explicitly includes them as targets.
 - Preserve authority boundaries: requirements belong in SRS, decisions in ADRs, sequencing in roadmap, schema truth in executable contracts, delivery detail in `specs/`, and realization in technical design.
 - Respect the active collaboration mode. If the environment is plan-only, produce a decision-complete plan instead of editing.
@@ -37,15 +41,17 @@ For reusable tables and checklists, read `references/technical-design-workflow.m
 
 2. **Create the impact map**
    - For each source point, assign evidence source, target technical-design section, authority type, and action.
+   - Include compact repository-relative links in the evidence source or a `Refs:` line when they materially improve traceability.
    - Mark actions as `promote`, `defer`, `ADR`, `SRS`, `roadmap`, `contract`, `code follow-up`, `spec follow-up`, or `do not promote`.
    - Show or summarize the impact map before edits when the task requires mutation.
    - Keep out-of-scope follow-ups visible instead of silently editing extra artifacts.
 
 3. **Update technical design**
-   - Translate stable content into realization-level prose, diagrams, and tables.
+   - Translate stable content into realization-level diagrams, tables, and concise prose.
    - Label current state, target state, transition state, and future state explicitly when mixed.
    - Prefer focused edits to the requested module, component, section, or concern.
-   - Link to governing ADRs, allocated SRS IDs, executable contracts, and verified specs when the trace materially helps.
+   - Link to governing ADRs, allocated SRS IDs, executable contracts, verified specs, source files, and tests when the trace materially helps.
+   - Use one abstraction level per diagram and keep captions short.
    - Do not copy proposal or spec prose wholesale; rewrite it for technical-design authority.
 
 4. **Sync implementation and specs**
@@ -85,7 +91,7 @@ Do not promote content into technical design when it is:
 ## Output Expectations
 
 For planning-only requests, output:
-- technical-design impact map,
+- compact linked technical-design impact map,
 - source and authority assessment,
 - proposed target sections,
 - follow-up list for non-technical-design artifacts,

--- a/.agents/skills/technical-design-manager/agents/openai.yaml
+++ b/.agents/skills/technical-design-manager/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Technical Design Manager"
   short_description: "Maintain technical design from governing docs."
-  default_prompt: "Use $technical-design-manager. Inputs: <SRS/architecture/ADR/spec/proposal/source files>. Target: <TECHNICAL_DESIGN.md section/module>. Produce an impact map first, then update only the agreed technical design scope."
+  default_prompt: "Use $technical-design-manager. Inputs: <governing docs/specs/src/tests/contracts>. Target: <TECHNICAL_DESIGN.md section/module>. Produce a compact linked impact map, prefer diagrams/tables over prose, update only the agreed technical design scope, then run drift and consistency review."

--- a/.agents/skills/technical-design-manager/references/technical-design-workflow.md
+++ b/.agents/skills/technical-design-manager/references/technical-design-workflow.md
@@ -17,6 +17,60 @@ Always produce or summarize this map before mutating long-lived technical design
 | Payload or wire format | Executable contract | Interface behavior summary | Schema authority | Link contract, avoid duplicating schema |
 | Research recommendation | Proposal or benchmark report | Target-state or future-state design | Evidence input | Promote only stable claims |
 
+## Compact Cross-Reference Pattern
+
+Use links to make claims traceable without flooding the design text. Prefer one compact reference block per subsection, table row, or diagram caption.
+
+Recommended pattern:
+
+```markdown
+Refs: SRS FR-x/AC-y; ADR-###; `specs/<feature>/plan.md`; `src/<module>.py`; `tests/<module>`.
+```
+
+Rules:
+
+- Use repository-relative links or inline code paths for project artifacts.
+- Link a source once where it supports a design claim; do not repeat the same link in nearby sentences.
+- Prefer stable requirement IDs, ADR IDs, spec paths, contract paths, and source/test files over broad document links.
+- Use a `Refs:` line under a diagram or table when several claims share the same evidence.
+- Report unresolved or unstable links instead of inventing anchors.
+
+## Diagram and Table Selection Guide
+
+Prefer visual structure when it reduces prose:
+
+| Design Need | Preferred Form | Use When |
+|-------------|----------------|----------|
+| Component boundary or ownership | Mermaid `flowchart` or responsibility table | Showing modules, dependencies, stores, and external providers |
+| Runtime interaction | Mermaid `sequenceDiagram` | Showing calls, async steps, gateway behavior, retries, or fallback |
+| Data shape or persistence ownership | Mermaid `classDiagram`, ER-style sketch, or compact table | Showing records, state, cache, lineage, and lifecycle |
+| Interface or contract relationship | Contract summary table | Linking executable schema truth without duplicating payload details |
+| Current vs target drift | Comparison matrix | Separating implemented, transition, target, and future behavior |
+
+Keep diagrams small enough to scan. Use prose only to explain non-obvious constraints, tradeoffs, or failure behavior.
+
+## Link Budget Checklist
+
+Before finalizing technical design content, check:
+
+- Every important design claim has either nearby evidence or an intentional no-link rationale.
+- Each subsection avoids repeated links to the same artifact.
+- Links point to the narrowest useful artifact: requirement ID, ADR, spec file, contract, source file, or test file.
+- Reference blocks support groups of claims instead of adding links to every sentence.
+- External proposal/research links are marked as evidence input, not authority.
+
+## Compactness Checklist
+
+Prefer:
+
+- one diagram plus a short caption over multi-paragraph flow explanation,
+- a responsibility table over repeated component prose,
+- a current/target matrix over mixed-state narrative,
+- a `Refs:` line over repeated parenthetical citations,
+- explicit follow-up bullets over speculative design paragraphs.
+
+Avoid exhaustive method lists, copied schemas, full proposal rationale, duplicated requirements, and implementation task lists unless the requested technical-design slice depends on them.
+
 ## Governing Context Checklist
 
 - Target technical design document and requested section or module are identified.
@@ -46,7 +100,8 @@ Always produce or summarize this map before mutating long-lived technical design
 - Separate current implementation from target or future behavior.
 - Explain runtime flow using a compact sequence, flowchart, or table when prose is ambiguous.
 - Explain state, persistence, cache, and lifecycle behavior when the component owns or transforms data.
-- Link relevant SRS IDs, ADRs, specs, source files, and contracts only where useful.
+- Link relevant SRS IDs, ADRs, specs, source files, tests, and contracts only where useful.
+- Prefer diagrams, matrices, and responsibility tables when they keep the update shorter and clearer than prose.
 - Avoid copying full code structure, exhaustive method lists, or schema payloads unless the design depends on them.
 
 ## State Labeling Rules
@@ -68,6 +123,8 @@ Do not present target or future state as implemented behavior.
 - Terminology matches SRS, architecture, ADRs, and current code where appropriate.
 - Links to SRS IDs, ADRs, specs, contracts, and source files resolve or are reported.
 - Diagrams are Mermaid where helpful and stay at one abstraction level.
+- Cross-references follow the link budget and do not flood prose.
+- Tables and diagrams replace verbose prose where they preserve meaning.
 - `src/` and `specs/` follow-ups are reported when outside the edit scope.
 - `git diff --check` passes for changed docs.
 - Changed-file scope matches the user request.


### PR DESCRIPTION
## Summary
- Expands the `technical-design-manager` skill guidance to favor compact, linked references and clearer realization-level output.
- Adds explicit guidance for Mermaid diagrams, matrices, and responsibility tables to reduce verbose prose.
- Updates the workflow checklist to emphasize stable repository-relative links, tighter traceability, and link-budget discipline.

## Testing
- Not run (not requested)