### PR TITLE
Expand research-to-architecture skill abilities

### DIFF
--- a/.agents/skills/research-to-architecture-adr/SKILL.md
+++ b/.agents/skills/research-to-architecture-adr/SKILL.md
@@ -1,52 +1,78 @@
 ---
 name: research-to-architecture-adr
-description: Convert research, proposal, benchmark, or side-chat synthesis documents into long-lived architecture design updates and ADR candidates. Use when Codex needs to propagate non-authoritative research into architecture docs, produce an impact map, decide ADR boundaries, update an ADR index, or run consistency review across architecture, SRS, roadmap, technical design, contracts, and traceability.
+description: Support high-level project architecture work from research, proposals, benchmark reports, specs, source evidence, and side-chat synthesis. Use when Codex needs to brainstorm architecture solution options, review architecture design work, convert non-authoritative research into architecture updates and ADR candidates, produce architecture impact maps, decide ADR boundaries, route lower-level realization work to $technical-design-manager, update an ADR index, or run consistency review across architecture, SRS, roadmap, technical design, contracts, specs, source code, and traceability.
 ---
 
 # Research to Architecture ADR
 
 ## Overview
 
-Use this skill to promote stable research/proposal claims into architecture design and ADRs without copying research prose wholesale. The workflow keeps proposal documents as evidence inputs and preserves repository authority boundaries.
+Use this skill as a project architecture assistant for brainstorming, decision support, architecture review, and promotion of stable research/proposal claims into architecture design and ADRs. The workflow keeps proposal documents as evidence inputs and preserves repository authority boundaries.
 
-For reusable tables and report templates, read `references/propagation-workflow.md` when the task asks for an impact map, ADR candidate analysis, consistency review, validation commands, or final propagation report.
+For reusable tables and report templates, read `references/propagation-workflow.md` when the task asks for an impact map, architecture option analysis, viewpoint mapping, ADR candidate analysis, architecture review, consistency review, validation commands, or final propagation report.
+
+## Architecture Scope Principles
+
+- Work at architecture abstraction: stakeholders, concerns, viewpoints, system/domain boundaries, major components, integration ownership, runtime/data/deployment flows, quality attributes, risks, and ADR-worthy decisions.
+- Keep architecture distinct from realization. Architecture answers what system shape, boundary, responsibility split, and decision record should exist; `$technical-design-manager` handles how modules, schemas, code paths, persistence, and domain interfaces realize those boundaries.
+- Prefer high-signal diagrams, viewpoint tables, option matrices, and decision summaries over implementation walkthroughs.
+- Label current, target, transition, and future state whenever architecture and implementation maturity differ.
+- Treat security, operations, data, API, and implementation details as architecture concerns only when they affect durable boundaries, quality attributes, trust boundaries, or decision records.
 
 ## Operating Rules
 
 - Treat research, proposal, benchmark, and side-chat content as non-authoritative input.
-- Inspect governing documents before editing: SRS, architecture design, technical design, roadmap, ADR index and existing ADRs, executable contracts, and traceability files when relevant.
+- Inspect governing documents before editing or reviewing: SRS, architecture design, technical design, roadmap, ADR index and existing ADRs, executable contracts, relevant specs, source evidence, tests, and traceability files when relevant.
 - Read only relevant sections after heading or search inspection unless full-document context is needed.
+- Use the project methodology first, with ISO 42010-aligned viewpoints, C4-style diagrams, arc42-style section routing, and ADR practice as supporting heuristics. Do not claim formal standards conformance unless the target document already does.
+- For brainstorming and review tasks, produce options, tradeoffs, risks, and feedback without editing unless the user asks for updates.
 - Always produce a visible impact map before mutating long-lived docs unless the user already supplied an equivalent map.
 - Promote each stable claim to the smallest owning artifact:
-  - Architecture design owns boundaries, viewpoints, major components, runtime/data flows, and current-vs-target labels.
-  - ADRs own durable decisions, options, consequences, and traceability.
+  - Architecture design owns stakeholders, concerns, viewpoints, boundaries, major components, runtime/data/deployment flows, risks, and current/target/transition/future-state labels.
+  - ADRs own durable decisions, drivers, options, lifecycle status, consequences, and traceability.
   - Technical design owns realization details, modules, schemas, persistence, and integration mechanics.
   - SRS owns WHAT-level requirements, constraints, acceptance criteria, interfaces, and traceability.
   - Roadmap owns runnable increments, gates, dependencies, and backlog mirrors.
+  - Specs own delivery-scoped intent, plans, tasks, and verification evidence.
   - Executable contracts own payload and wire schema truth.
-- Do not edit SRS, roadmap, technical design, contracts, or traceability unless the user explicitly includes them as targets.
+- Do not edit SRS, roadmap, technical design, contracts, specs, source code, tests, or traceability unless the user explicitly includes them as targets.
 - Ask the user before creating new ADRs when multiple plausible decision boundaries exist.
+- When content is out of architecture/ADR scope, route it to the correct owner and report the follow-up rather than forcing it into architecture prose.
 - Respect the active collaboration mode. If the environment is plan-only, produce a decision-complete plan instead of editing.
+
+## Out of Scope and Companion Routing
+
+- Use `$technical-design-manager` for technical realization: modules, package structure, code paths, class responsibilities, persistence mechanics, detailed interfaces, executable implementation sync, and `TECHNICAL_DESIGN.md` updates.
+- Route new or changed WHAT-level obligations to SRS.
+- Route sequencing, delivery phases, gates, and backlog mirrors to roadmap or Spec Kit artifacts under `specs/`.
+- Route payload and wire schema truth to executable contracts such as OpenAPI or JSON Schema.
+- Route code, tests, migrations, and implementation tasks to implementation planning or coding workflows.
+- Route deep security assessment to security review skills or threat modeling, while keeping only architecture-significant trust boundaries and security decisions here.
+- Route operational procedures, recovery steps, and support workflows to runbooks or operations policy; keep only architecture-level operations boundaries and quality scenarios here.
 
 ## Workflow
 
 1. **Load context**
-   - Read the proposal/research input.
+   - Identify the task mode: brainstorm, review, promote, architecture update, ADR, consistency check, or mixed.
+   - Read the proposal/research/spec/source input relevant to that mode.
    - Read the target architecture document and relevant existing sections.
    - Read the ADR index and nearby ADRs for naming, status, traceability, and style.
-   - Read SRS, roadmap, technical design, executable contracts, and traceability only as needed to avoid authority drift.
+   - Read SRS, roadmap, technical design, executable contracts, specs, source files, tests, and traceability only as needed to avoid authority drift.
 
 2. **Create the impact map**
-   - For each proposal point, assign target document, target section/artifact, authority type, and action.
+   - For each proposal point or architecture concern, assign target document, target section/artifact, authority type, and action.
    - Mark actions as `promote`, `defer`, `ADR`, `SRS`, `technical design`, `roadmap`, `contract`, or `do not promote`.
+   - Map stakeholder concerns and architecture viewpoints when the update affects boundaries, flows, data, deployment, operations, or quality attributes.
+   - Mark out-of-scope details with the correct companion owner, especially `$technical-design-manager` for realization detail.
    - Show or summarize the impact map before edits when the task requires mutation.
    - Report follow-ups outside the requested edit scope instead of silently editing extra documents.
 
 3. **Update architecture design**
-   - Add or refine boundaries, system context, component relationships, runtime/data flows, provider/integration boundaries, and state labels.
+   - Add or refine stakeholders, concerns, viewpoint scope, system context, component relationships, runtime/data/deployment flows, provider/integration boundaries, risk notes, and state labels.
    - Keep architecture at viewpoint level. Do not add detailed implementation module placement, exhaustive field schemas, or requirement tables.
    - Label current state, target state, future state, and transition state explicitly.
    - Track these four states when relevant: current implemented behavior, target proposed behavior, transition/migration behavior, and future optional behavior.
+   - Prefer compact C4-style Mermaid diagrams and viewpoint tables when they make the architecture clearer than prose.
 
 4. **Create or update ADRs**
    - Use an ADR when the proposal chooses a durable direction among meaningful alternatives.
@@ -54,11 +80,13 @@ For reusable tables and report templates, read `references/propagation-workflow.
    - Inspect the existing ADR index and filenames before choosing an ADR number or slug.
    - Use the next available sequence number; do not reuse existing ADR IDs.
    - Include status, context, decision, considered options, consequences, and traceability.
+   - Treat accepted or rejected ADRs as stable history; create a superseding ADR instead of silently rewriting the old decision unless the user explicitly asks for a correction.
    - Update the ADR index when creating, renaming, or materially revising ADRs.
 
 5. **Run consistency review**
    - Check stale terminology, duplicate authority, broken links, missing traceability, and current-vs-target drift.
-   - Check that architecture and ADRs do not contradict SRS, roadmap, technical design, or executable contracts.
+   - Check that architecture and ADRs do not contradict SRS, roadmap, technical design, specs, source evidence, executable contracts, or traceability.
+   - Check diagram quality, viewpoint fit, ADR boundary fit, and whether claims are promoted to the smallest owning artifact.
    - Run `git diff --check` on changed Markdown files and report changed-file scope.
 
 ## ADR Boundary Heuristics
@@ -74,8 +102,11 @@ Examples:
 
 For planning-only requests, output:
 - impact map,
+- architecture options and tradeoff assessment when brainstorming,
+- review findings ordered by severity when reviewing,
 - ADR candidates and decision-boundary questions,
 - proposed architecture sections,
+- out-of-scope routing and companion-skill follow-ups,
 - consistency review plan.
 
 For implementation requests, deliver:
@@ -83,4 +114,4 @@ For implementation requests, deliver:
 - dedicated ADRs where justified,
 - ADR index update,
 - validation results,
-- follow-up list for SRS, roadmap, technical design, contracts, or traceability items outside scope.
+- follow-up list for `$technical-design-manager`, SRS, roadmap, specs, contracts, code, tests, security review, operations, or traceability items outside scope.

--- a/.agents/skills/research-to-architecture-adr/agents/openai.yaml
+++ b/.agents/skills/research-to-architecture-adr/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Research to Architecture ADR"
+  display_name: "Architecture and ADR skills"
   short_description: "Promote research into architecture and ADRs."
-  default_prompt: "Use $research-to-architecture-adr. Inputs: <proposal/research files>. Targets: <architecture file>, <ADR directory/index>. Produce an impact map first, then promote stable claims only into the listed targets."
+  default_prompt: "Use $research-to-architecture-adr. Mode: <brainstorm/review/promote/update/ADR/consistency>. Inputs: <research/proposal/spec/source/benchmark files>. Targets: <architecture file and/or ADR directory/index>. Stay at high-level architecture scope, produce an impact map first, label current/target/transition/future state, route realization detail to $technical-design-manager, update only agreed targets, then run architecture and ADR consistency review."

--- a/.agents/skills/research-to-architecture-adr/references/propagation-workflow.md
+++ b/.agents/skills/research-to-architecture-adr/references/propagation-workflow.md
@@ -2,6 +2,60 @@
 
 Use these templates when converting research or proposal documents into architecture design updates and ADRs.
 
+## Architecture Task Router
+
+Classify the request before editing:
+
+| Task Mode | Use When | Default Output | Default Edit Behavior |
+|-----------|----------|----------------|-----------------------|
+| Brainstorm | User asks for solution options, design alternatives, or tradeoff help | Options, tradeoff matrix, recommended direction, open decisions | No edits unless explicitly requested |
+| Review | User asks to evaluate architecture/design work | Findings by severity, drift/misconceptions, follow-ups | No edits unless explicitly requested |
+| Promote | User provides research/proposal/spec evidence to propagate | Impact map and target artifact actions | Edit only requested targets |
+| Architecture Update | User asks to update architecture docs | Viewpoint-level changes, diagrams, correspondences | Architecture docs only by default |
+| ADR | User asks for durable decisions or ADRs | ADR candidates, boundary questions, ADR files/index | Ask before creating ADRs when boundaries are ambiguous |
+| Consistency Check | User asks for alignment/drift review | Cross-artifact consistency report | No edits unless explicitly requested |
+
+If a request combines modes, run the impact map first and keep each output tied to its authority owner.
+
+## Architecture Abstraction-Level Checklist
+
+Keep architecture work at the level of:
+
+- stakeholders, concerns, viewpoints, and scope boundaries,
+- system/domain context, external actors, and external dependencies,
+- major components, containers, responsibilities, and dependency direction,
+- runtime, data, deployment, integration, and operations flows,
+- quality attributes, risks, trust boundaries, and degraded-mode boundaries,
+- durable decisions that need ADRs or ADR follow-ups.
+
+Do not turn architecture sections into module inventories, schema definitions, code walkthroughs, implementation task lists, or delivery plans. Route those to the correct companion artifact.
+
+## Out-of-Scope Routing Matrix
+
+| Content Found | Do Not Put It In Architecture As | Correct Owner | Action |
+|---------------|----------------------------------|---------------|--------|
+| Detailed modules, packages, classes, code paths, algorithms | Architecture implementation prose | `$technical-design-manager` / `TECHNICAL_DESIGN.md` | Report technical-design follow-up |
+| Persistence mechanics, indexes, cache policy details, schema fields | Architecture data-model detail | `$technical-design-manager` or executable data contracts | Report technical-design or contract follow-up |
+| New WHAT-level behavior, constraints, acceptance criteria | Architecture requirement text | SRS | Report SRS follow-up |
+| Sequencing, rollout phases, backlog mirrors, delivery gates | Architecture roadmap | Roadmap or `specs/` | Report roadmap/spec follow-up |
+| Payloads, wire formats, API schema examples | Architecture schema authority | Executable contracts | Report contract follow-up |
+| Source code edits, migrations, tests, implementation tasks | Architecture action list | Implementation workflow | Report code/test follow-up |
+| Deep security vulnerabilities, exploit paths, mitigations | Architecture security audit | Security review or threat modeling | Keep only architecture-significant trust boundary or ADR |
+| Operational procedures, runbooks, incident response steps | Architecture operations manual | Runbooks or operations policy | Keep only operations boundary or quality scenario |
+
+## Companion Skill Handoff Pattern
+
+Use this when architecture review exposes realization work:
+
+```markdown
+Use `$technical-design-manager`.
+Inputs: <architecture section>, <ADR/SRS/spec/source evidence>.
+Target: <TECHNICAL_DESIGN.md section/module>.
+Task: Translate the approved architecture boundary into compact realization design, produce a linked impact map, prefer diagrams/tables, and report code/spec follow-ups outside scope.
+```
+
+Use the handoff pattern as a follow-up, not as an instruction to edit technical design unless the user explicitly expands the target documents.
+
 ## Impact Map
 
 Always produce or summarize this map before mutating long-lived documents unless the user supplied an equivalent map.
@@ -15,6 +69,48 @@ Always produce or summarize this map before mutating long-lived documents unless
 | Sequencing, dependency, or delivery gate | Roadmap | Phase, milestone, backlog mirror | Planning authority | Promote as traceable delivery sequence |
 | Payload or wire format | Executable contract | OpenAPI, JSON Schema, or owned contract artifact | Schema authority | Promote to machine-readable contract |
 | Research rationale or external comparison | Proposal or benchmark report | Research log, benchmark matrix, reference index | Evidence input | Keep as supporting evidence |
+| Detailed realization or implementation evidence | Technical design | `TECHNICAL_DESIGN.md` section/module | Realization authority | Hand off to `$technical-design-manager` unless explicitly targeted |
+
+## Stakeholder, Concern, and Viewpoint Map
+
+Use this map when an architecture change affects multiple audiences or views.
+
+| Proposal Point / Concern | Stakeholder(s) | Architecture Viewpoint | Target Section | State Label | Action |
+|--------------------------|----------------|------------------------|----------------|-------------|--------|
+| Boundary or external dependency | Product, Security, Architecture Owners, Engineers | Context and Boundary | System context, dependency table, boundary note | Current / Target / Transition / Future | Promote or defer |
+| Component ownership or dependency direction | Engineers, Architecture Owners | Logical | Building blocks, responsibility table, dependency diagram | Current / Target / Transition / Future | Promote or ADR |
+| Runtime behavior or failure path | Engineers, SRE, QA | Process | Runtime sequence, degraded-mode flow, resilience note | Current / Target / Transition / Future | Promote or technical design follow-up |
+| State, evidence, data, or lifecycle boundary | Data, Security, Engineers | Information and State | Data/state allocation, lifecycle table | Current / Target / Transition / Future | Promote or contract follow-up |
+| Deployment or operational concern | SRE, Security, Architecture Owners | Deployment / Operations | Topology, health, observability, runbook boundary | Current / Target / Transition / Future | Promote or operations follow-up |
+| Behavioral policy or guardrail | AI maintainers, Security, Product | Prompt and Behavior | Guardrail boundary, tool-risk view, behavior taxonomy | Current / Target / Transition / Future | Promote or ADR |
+
+## Architecture Section Selection Guide
+
+Route content to the smallest useful architecture section. Use project methodology first; use ISO 42010, C4, and arc42 as heuristics, not as claims of formal conformance.
+
+| Content Type | Architecture Target | Useful Form |
+|--------------|---------------------|-------------|
+| Entity, scope, external actors, external systems | Context and Boundary view | C4-style context diagram, dependency table |
+| Containers, major building blocks, ownership | Logical view | C4-style container/component sketch, responsibility table |
+| Important runtime scenarios | Process view | Mermaid sequence or flowchart |
+| State, memory, cache, evidence, data lifecycle | Information and State view | State/lifecycle table, data-flow diagram |
+| Deployment topology, environments, probes, scaling | Deployment view | Deployment table or topology sketch |
+| Operations, observability, failure/degraded behavior | Operations and Maintenance view | Quality scenario table, decision flow |
+| Prompt, guardrails, tool policy, behavioral constraints | Prompt and Behavior view | Boundary diagram, risk taxonomy table |
+| Durable choice among meaningful alternatives | ADR | ADR with decision, options, consequences |
+| Detailed modules, schemas, algorithms, storage mechanics | Technical design | Report follow-up unless target includes technical design |
+
+## Option Tradeoff Matrix
+
+Use this for brainstorming and decision support before creating or updating ADRs.
+
+| Option | Summary | Benefits | Costs / Risks | Fit to SRS / Architecture | Implementation Impact | ADR Needed? |
+|--------|---------|----------|---------------|---------------------------|-----------------------|-------------|
+| Option A |  |  |  |  |  | Yes / No |
+| Option B |  |  |  |  |  | Yes / No |
+| Recommended |  |  |  |  |  |  |
+
+State the recommendation separately and identify what evidence would change it.
 
 ## Architecture Promotion Checklist
 
@@ -25,6 +121,9 @@ Always produce or summarize this map before mutating long-lived documents unless
 - Is transition/migration behavior separated from future optional behavior?
 - Are implementation details kept for technical design rather than architecture?
 - Are links added to governing ADRs, SRS IDs, roadmap milestones, or benchmark evidence only when materially useful?
+- Does every diagram stay within one viewpoint and one abstraction level?
+- Are C4-style context/container/component/dynamic/deployment diagrams used only where they clarify the architecture?
+- Are low-level realization details routed to `$technical-design-manager` instead of embedded in architecture?
 
 ## ADR Candidate Checklist
 
@@ -49,12 +148,38 @@ Avoid an ADR when:
 - Update the ADR index in the same change whenever creating, renaming, or materially revising ADRs.
 - Link ADRs to relevant architecture sections, SRS IDs, roadmap milestones, benchmark reports, or proposal inputs only when the trace is useful.
 
+## ADR Lifecycle Checklist
+
+| Status | Meaning | Skill Behavior |
+|--------|---------|----------------|
+| Proposed | Decision is ready for review but not accepted | Create or update when the user asks for candidate ADRs |
+| Accepted | Decision is approved and governs future work | Treat as stable decision history; do not rewrite materially without explicit correction scope |
+| Superseded | Later ADR replaces this decision | Create a new ADR and update the index/linkage |
+| Rejected | Decision was considered and rejected | Preserve rationale to avoid repeat debate |
+
+Ask the user before creating ADRs when multiple decision boundaries are plausible, when status is unclear, or when superseding an accepted ADR may be required.
+
+## Architecture Review Checklist
+
+Use findings-first style for review tasks:
+
+- Boundary accuracy: system, domain, external provider, and data boundaries match governing docs and current evidence.
+- Viewpoint fit: content belongs in architecture, not SRS, technical design, roadmap, contract, spec, or runbook.
+- Decision coverage: durable choices have ADRs or documented ADR follow-ups.
+- Abstraction level: architecture sections avoid module inventories, code walkthroughs, schema fields, and delivery task lists.
+- Companion routing: technical realization work is handed off to `$technical-design-manager`; requirements, roadmap, contracts, code, tests, security, and operations work are routed to their owners.
+- Current/target drift: implemented, transition, target, and future-state claims are labeled correctly.
+- Duplicate authority: requirements, schemas, implementation details, and delivery sequencing are not duplicated in architecture.
+- Diagram quality: Mermaid/C4-style diagrams have clear scope, one abstraction level, readable labels, and no stale terminology.
+- Traceability: useful links to SRS IDs, ADRs, roadmap items, technical design, contracts, specs, or source evidence are present and not excessive.
+- Consistency: architecture and ADRs do not contradict SRS, technical design, roadmap, specs, source evidence, executable contracts, or traceability.
+
 ## Consistency Review Checklist
 
 - One owning authority exists for each promoted claim.
 - SRS owns requirements; ADRs own decisions; architecture owns boundaries; technical design owns realization; executable contracts own schemas; roadmap owns sequencing.
 - Proposal and benchmark documents are cited as evidence inputs, not overriding authority.
-- New architecture and ADR language does not contradict SRS, roadmap, technical design, code current state, or executable contracts.
+- New architecture and ADR language does not contradict SRS, roadmap, technical design, specs, code current state, tests, traceability, or executable contracts.
 - Terminology is consistent across updated documents.
 - Current-state, target-state, transition-state, and future-state wording is explicit where relevant.
 - ADR index links resolve.


### PR DESCRIPTION
## Summary
- Broaden the research-to-architecture ADR skill to cover brainstorming, review, promotion, and consistency checks
- Add scope guidance, companion-skill routing, and architecture abstraction rules
- Expand the workflow and reference templates with impact maps, viewpoint mapping, ADR lifecycle checks, and review heuristics

## Testing
- Not run (not requested)