### PR TITLE
docs(spec-kit): align local SDD guidance with installed workflow

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,38 +1,32 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version Change: 1.3.0 → 2.0.0 (MAJOR)
-Bump Rationale: Replaced an agent-memory-centric constitution with a repo-wide practical
-  constitution aligned to current Spec-Driven Development, layered architecture, contract
-  synchronization, multi-surface delivery, and AI runtime governance. v2.1.0 adds explicit
-  document-referencing rules governing how `docs/` documents are referenced during spec-kit
-  phases, including anchor-level precision, lifecycle obligations, and cross-reference
-  validation.
+Version Change: 2.1.0 -> 2.2.0 (MINOR)
+Bump Rationale: Added explicit governance for the repository's current local Spec Kit
+  operating state: command normalization, sync gate posture, feature status semantics,
+  spec persistence policy, and current REST contract ownership. This expands process
+  obligations without replacing the existing core principles.
 
 Modified Principles:
-- Memory Never Stores Facts → Spec-Driven, Traceable Delivery
-- RAG Never Stores Opinions → Layered Boundaries and Explicit Ownership
-- Fine-Tuning Never Stores Knowledge → Evidence-Grounded Financial Intelligence
-- Prompting Controls Behavior, Not Data → Prompts, Memory, and Fine-Tuning Control Behavior, Not Truth
-- Tools Compute Numbers, LLM Reasons About Them → Deterministic Tools and Contracted Interfaces
-- Investment Data Sources Are External → Testability and Observability Are First-Class
-- Market Manipulation Safeguards Are Enforced → Secure, Simple, Reversible Change
+- Spec-Driven, Traceable Delivery: expanded with current status and sync obligations.
+- Deterministic Tools and Contracted Interfaces: clarified current `docs/openapi.yaml`
+  ownership until governed migration.
 
 Added Sections:
-- Artifact and Documentation Boundaries
-- Document Referencing in Spec-Kit Workflows
-- Spec Kit Lifecycle Obligations
-- Delivery Sync Gates
+- Current Spec Kit Command Surface
+- Spec Persistence and Feature Status Semantics
 
 Removed Sections:
-- None; earlier agent-specific governance was absorbed into repo-wide principles and Memory and AI Runtime Boundaries.
+- None
 
 Template Consistency Check:
-- .specify/templates/plan-template.md: ✅ updated in v2.0.0; doc-referencing rules are cross-cutting and are now captured in the constitution directly; no template structural change needed
-- .specify/templates/spec-template.md: ✅ updated in v2.0.0
-- .specify/templates/tasks-template.md: ✅ updated in v2.0.0
-- .specify/templates/constitution-template.md: ✅ checked, no change required
-- .github/prompts/speckit.constitution.prompt.md: ✅ checked, no change required
+- .specify/templates/spec-template.md: updated before constitution sync; aligned with
+  governance context, traceability target, sync target, contract impact, and lifecycle status.
+- .specify/templates/plan-template.md: updated before constitution sync; aligned with
+  governance and traceability context, sync reports, public contract impact, and status target.
+- .specify/templates/tasks-template.md: updated before constitution sync; aligned with
+  traceability, contract, long-lived docs, sync gate, and anchor validation tasks.
+- .specify/templates/commands/*.md: not present in this repository; no update required.
 
 Follow-up TODOs:
 - None
@@ -119,12 +113,16 @@ contract, runbook, or feature spec before changing code, docs, or IaC.
 #### 2. Respect Artifact Lifecycles and Locations
 `docs/` is the long-lived baseline, `specs/` is the governed delivery evidence area, and
 `.specify/` is runtime and tooling support. Stable knowledge is promoted from `specs/` to `docs/`
-only after verification.
+only after verification. Active feature specs remain living artifacts until closeout; verified
+feature directories become delivery evidence and SHOULD flow forward into long-lived documents
+rather than being repeatedly rewritten.
 
 #### 3. Keep Contracts and Sync Artifacts Current
 When stable behavior changes, update `docs/openapi.yaml`, `specs/spec-traceability.yaml`,
 `specs/spec-sync-status.md`, affected reverse-trace documents, and impacted technical design or
-runbook artifacts in the same delivery cycle when relevant.
+runbook artifacts in the same delivery cycle when relevant. The sync report MUST be regenerated
+with `python scripts/sync_spec_status.py --gate` when requirement coverage, feature lifecycle
+status, or evidence paths change.
 
 #### 4. Protect Secrets and Privileged Access
 Secrets MUST NOT appear in source, logs, docs, or test fixtures. Use environment variables,
@@ -160,6 +158,9 @@ test updates, and justify any unavoidable complexity against a simpler alternati
   status.
 - `.specify/` is the project-local Spec Kit runtime and configuration area and MUST NOT be used
   as the canonical store for governed feature delivery evidence.
+- `docs/openapi.yaml` is the current canonical REST contract. A future move to
+  `docs/domains/backend/api/openapi.yaml` MUST be handled as a governed migration that updates
+  references, validation paths, CI or scripts, and contributor guidance in one change set.
 - If code, specs, contracts, and long-lived docs disagree, fix the authoritative artifact first,
   then reconcile dependent references.
 
@@ -207,9 +208,33 @@ agentic workflow context.
 - When renaming a section heading in a `docs/` document, use grep or equivalent search to find
   all inbound references across `specs/`, other `docs/` files, and `.github/` customization
   files before committing the rename.
-- Placeholder or template-style references such as `[link to relevant design doc]` MUST NOT
+- Placeholder or template-style references such as `link to relevant design doc` MUST NOT
   survive into a published spec, plan, or task artifact. Every reference MUST be resolved to a
   concrete file path and section anchor before the artifact leaves draft status.
+
+### Spec Persistence and Feature Status Semantics
+
+Feature directories under `specs/` MUST use lifecycle status names consistently. `Draft`,
+`Clarified`, `Planned`, `Implemented`, `Verified`, `Backfilled`, and `Superseded` are the
+approved status vocabulary for feature `spec.md` headers, traceability notes, and sync
+discussion.
+
+- `Draft` applies before clarification and planning have completed.
+- `Clarified` applies when ambiguity has been resolved and planning can proceed.
+- `Planned` applies when `plan.md` exists and the design direction is accepted.
+- `Implemented` applies when tasks are complete and implementation evidence exists, but the
+  final verification marker is absent.
+- `Verified` applies only when `review.md`, `.verify-done`, complete tasks, and the sync gate
+  all support the verified state.
+- `Backfilled` applies only to governance restoration for pre-existing behavior.
+- `Superseded` applies when a feature directory is retained for history and points to its
+  replacement authority.
+
+Active feature work MAY flow backward from implementation findings into `spec.md`, `plan.md`, or
+`tasks.md`, but that reconciliation MUST be followed by analysis or sync review. Verified feature
+directories SHOULD flow forward into `docs/`, contracts, traceability, roadmap, or ADRs instead
+of being mutated as active design documents. Material behavior changes after verification MUST
+use a follow-up feature, governed doc update, or explicit supersession link.
 
 ### Memory and AI Runtime Boundaries
 
@@ -272,8 +297,8 @@ These items MUST stay in retrieval, tools, or governed data stores rather than L
 
 - Non-trivial work MUST follow the repository's Spec-Driven Development chain: governed
   requirements and design inputs, `speckit.constitution`, `speckit.specify`, clarification and
-  checklist steps when needed, `speckit.plan`, `speckit.tasks`, implementation, verification,
-  and delivery synchronization.
+  checklist steps when needed, `speckit.plan`, `speckit.tasks`, implementation,
+  `speckit.verify-tasks.run`, `speckit.verify.run`, and delivery synchronization.
 - Plans MUST identify governing artifacts, affected domains, sync targets, validation strategy,
   architecture impact, and rollback or migration implications.
 - Tasks MUST include tests, contract updates, traceability refresh, and long-lived doc sync work
@@ -283,6 +308,27 @@ These items MUST stay in retrieval, tools, or governed data stores rather than L
   Workflows defines the responsibility per phase.
 - Documentation-first work MAY start from documentation-focused agents or workflows, but it MUST
   obey the same artifact boundaries and sync duties.
+
+### Current Spec Kit Command Surface
+
+The constitution governs the current local command surface, not only upstream examples. As of the
+current repository state, contributors MUST use these normalized surfaces unless a governed Spec
+Kit upgrade changes installed commands and managed files:
+
+- Pre-implementation review: `speckit.fleet.review`; historical `speckit.review` is shorthand
+  only.
+- Phantom completion detection: `speckit.verify-tasks.run`; historical `speckit.verify-tasks`
+  is shorthand only.
+- Post-implementation verification: `speckit.verify.run`; historical `speckit.verify` is
+  shorthand only.
+- Traceability and sync gate: `python scripts/sync_spec_status.py --gate`; `speckit.sync.*` is
+  not an installed/enabled surface until `specify extension list` confirms adoption.
+- Upstream convergence commands such as `speckit.converge` are upgrade-gated and MUST NOT be
+  documented as locally available until the CLI, prompts, skills, and managed files expose them.
+
+Copilot remains the default integration unless changed by a governed `specify integration use`
+operation. Codex may remain installed as a secondary integration for portability, but mixed-agent
+delivery MUST preserve one coherent feature workflow and one authoritative artifact set.
 
 ### Verification and Delivery Gates
 
@@ -316,6 +362,8 @@ These items MUST stay in retrieval, tools, or governed data stores rather than L
   requirement coverage or feature verification status changes.
 - Domain reverse-trace documents, such as `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`, MUST be
   updated when their requirement mappings change.
+- `python scripts/sync_spec_status.py --gate` MUST pass before mapped requirement-linked feature
+  work is considered synchronized.
 - Affected technical design, architecture, or runbook documents MUST be synchronized when stable
   behavior becomes part of the long-lived baseline.
 
@@ -342,6 +390,9 @@ specific concern MUST then be reconciled across dependent artifacts.
 - `/speckit.tasks`, implementation, review, and post-implementation verification MUST confirm
   that required tests, contracts, traceability, and long-lived doc sync tasks are present when
   relevant.
+- `speckit.verify-tasks.run`, `speckit.verify.run`, and
+  `python scripts/sync_spec_status.py --gate` are the current closeout gates for implemented
+  feature work when those surfaces apply.
 - Any approved deviation MUST be written as an explicit justification in the affected plan,
   review, ADR, or equivalent governing artifact.
 
@@ -350,4 +401,4 @@ specific concern MUST then be reconciled across dependent artifacts.
 - **MINOR**: New articles, principles, or materially expanded guidance
 - **PATCH**: Clarifications, typo fixes, non-semantic refinements
 
-**Version**: 2.1.0 | **Ratified**: 2026-01-27 | **Last Amended**: 2026-06-02
+**Version**: 2.2.0 | **Ratified**: 2026-01-27 | **Last Amended**: 2026-07-01

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -36,6 +36,28 @@
 
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]
 
+## Governance and Traceability Context
+
+<!--
+  ACTION REQUIRED: Replace placeholders with repo-specific authority and sync details.
+  Use exact file paths and anchor-level references. If a row is not applicable, say N/A
+  and explain why.
+-->
+
+**Source Requirements**: [SRS/system/domain IDs and links carried from spec.md]
+
+**Authority References**: [Constitution, architecture, technical design, ADR, roadmap, research, contract, or runbook anchors used to constrain the plan]
+
+**Traceability Updates**: [Required `specs/spec-traceability.yaml` edits, expected `mapped_srs_items`, functional groups, coverage status, and evidence paths]
+
+**Sync Report Updates**: [When to run `python scripts/sync_spec_status.py --gate` and which generated reports must change]
+
+**Public Contract Impact**: [N/A, or exact contract files. Current REST contract authority is `docs/openapi.yaml` until a governed migration changes it.]
+
+**Long-Lived Documentation Impact**: [N/A, or exact `docs/` targets that must be promoted after implementation or verification]
+
+**Lifecycle Status Target**: [Planned, Implemented, Verified, Backfilled, or Superseded closeout expectation]
+
 ## Constitution Check
 
 *GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*

--- a/.specify/templates/spec-template.md
+++ b/.specify/templates/spec-template.md
@@ -8,6 +8,26 @@
 
 **Input**: User description: "$ARGUMENTS"
 
+## Governance Context *(mandatory)*
+
+<!--
+  ACTION REQUIRED: Ground this feature in repository authority before writing user stories.
+  Use exact file paths and anchor-level references where possible. If a required source
+  does not exist, state "N/A" and explain why.
+-->
+
+**Source Requirements**: [SRS/system/domain requirement IDs and links, e.g., `FR-1.2.3` in `docs/domains/agent/SOFTWARE_REQUIREMENTS_SPECIFICATION.md#...`]
+
+**Authoritative Inputs**: [Constitution, architecture, technical design, ADR, roadmap, research, contract, or runbook references with anchors]
+
+**Traceability Target**: [Feature entry to add/update in `specs/spec-traceability.yaml`, including expected `mapped_srs_items`, functional groups, and coverage status]
+
+**Sync Targets**: [Long-lived docs, contracts, traceability reports, or runbooks that must be updated if this feature changes behavior]
+
+**Contract Impact**: [N/A, or exact executable contract paths such as `docs/openapi.yaml` or `specs/<feature>/contracts/...` that must change]
+
+**Lifecycle Status Rule**: [Expected starting status and promotion path: Draft -> Clarified -> Planned -> Implemented -> Verified, Backfilled, or Superseded]
+
 ## User Scenarios & Testing *(mandatory)*
 
 <!--

--- a/.specify/templates/tasks-template.md
+++ b/.specify/templates/tasks-template.md
@@ -26,6 +26,16 @@ description: "Task list template for feature implementation"
 - **Mobile**: `api/src/`, `ios/src/` or `android/src/`
 - Paths shown below assume single project - adjust based on plan.md structure
 
+## Governance Task Requirements
+
+Generated tasks MUST include exact file paths for all governance work that applies to the feature:
+
+- Update `specs/spec-traceability.yaml` when SRS scope, evidence paths, coverage status, or lifecycle status changes.
+- Update public contracts when behavior changes. The current REST contract authority is `docs/openapi.yaml` until a governed migration changes that path.
+- Add or update long-lived docs only for stable knowledge that belongs in `docs/`, and cite exact target anchors.
+- Regenerate sync reports with `python scripts/sync_spec_status.py --gate` after traceability or feature status changes.
+- Validate anchor-level references used by spec, plan, tasks, docs, and contract links.
+
 <!--
   ============================================================================
   IMPORTANT: The tasks below are SAMPLE TASKS for illustration purposes only.
@@ -157,6 +167,11 @@ Examples of foundational tasks (adjust based on your project):
 - [ ] TXXX [P] Additional unit tests (if requested) in tests/unit/
 - [ ] TXXX Security hardening
 - [ ] TXXX Run quickstart.md validation
+- [ ] TXXX Update `specs/spec-traceability.yaml` with final SRS mappings, coverage status, evidence paths, and lifecycle status
+- [ ] TXXX [P] Update affected long-lived docs in `docs/` with exact section anchors, if this feature promotes stable knowledge
+- [ ] TXXX [P] Update `docs/openapi.yaml` or feature contract files if public API behavior, payloads, or compatibility obligations changed
+- [ ] TXXX Run `python scripts/sync_spec_status.py --gate` and commit regenerated `specs/spec-sync-status.md` plus reverse traceability output
+- [ ] TXXX Validate Markdown links and anchor references touched by this feature
 
 ---
 

--- a/docs/spec-driven development (SDD)/spec-kit HOW-TO.md
+++ b/docs/spec-driven development (SDD)/spec-kit HOW-TO.md
@@ -100,7 +100,21 @@ specify workflow list
 
 For documentation-first work in Copilot, contributors can start with the [Documentation Spec Maintainer Agent](../../.github/agents/documentation.spec-maintainer.agent.md). It is the fastest entry point for maintaining long-lived docs, delivery-scoped specs, traceability, and Copilot customization files while staying inside the same SDD lifecycle described in this HOW-TO. When feature-scoped artifacts are needed, the agent can hand off to `speckit.specify`, `speckit.plan`, and `speckit.verify.run`.
 
-### 2.3 Install or Recreate Local CLI Access
+### 2.3 Current Installed State
+
+As of 2026-07-01, this repository should be operated from the local installed truth below. Upstream documentation is useful context, but a command is adopted locally only after `specify version --features --json`, `specify extension list`, and the installed prompt/skill files confirm it exists in this checkout.
+
+| Surface | Current local state | Operating interpretation |
+|---------|---------------------|--------------------------|
+| Spec Kit CLI | `specify 0.12.0`; latest observed upstream release is `0.12.2` from 2026-06-30 | Use local command availability first; treat newer upstream commands as upgrade-gated until the CLI and managed files are upgraded together. |
+| CLI feature flags | `self_check_command`, `integration_upgrade_command`, `integration_use_command`, `workflow_catalog`, `bundled_templates`, and multi-install metadata support are present | The repo can use `self check`, `self upgrade`, `integration use`, and `integration upgrade`, but must still review managed-file diffs. |
+| Integration metadata | `.specify/integration.json` uses metadata version `0.10.2`, default integration `copilot`, installed integrations `copilot` and `codex` | Copilot remains the default integration unless a governed change switches it with `specify integration use codex`. |
+| Integration status | `specify integration status` currently exits non-zero because Copilot + Codex is a forced multi-install and Copilot is not declared multi-install safe upstream | Treat `unsafe-multi-install` as a known portability warning only when no managed files are missing or invalid. Missing manifests, invalid manifests, or unexpected default changes remain blockers. |
+| Workflow catalog | `specify workflow info speckit` reports the six-step bundled workflow: specify, review-spec, plan, review-plan, tasks, implement | This repository's 18-step SDLC is a governance overlay around the bundled workflow, not a replacement for the local prompt/skill commands. |
+| Installed extensions | Understanding, Verify Tasks, Spec Kit Utilities, Git, Fleet, Verify, Memory Loader, Architecture Workflow, Coding Agent Context, Research Harness, Security Review, and Architecture Guard are enabled | Use current extension command names from this HOW-TO instead of older shorthand names. |
+| Sync extension | A sync extension package may exist in `.specify/extensions/sync`, but `speckit.sync.*` is not installed/enabled in the current command surface | Use `python scripts/sync_spec_status.py --gate` for supported sync reporting until a governed extension install adopts `speckit.sync.*`. |
+
+### 2.4 Install or Recreate Local CLI Access
 
 Persistent installation:
 
@@ -123,7 +137,7 @@ specify init --here --integration copilot --script ps
 
 Only re-run initialization when you intentionally need to restore or recreate `.specify/` and related managed assets.
 
-### 2.4 Upgrade an Existing Spec Kit Setup
+### 2.5 Upgrade an Existing Spec Kit Setup
 
 When upgrading Spec Kit in this repository, treat the CLI tool and the project files as separate layers. Upgrade the CLI to get new features and bug fixes, then refresh the repository's installed Spec Kit assets so prompts, templates, scripts, and shared memory stay aligned with the version you are actually running.
 
@@ -133,23 +147,38 @@ Use the following commands before upgrading:
 
 ```powershell
 specify self check
-specify version
+specify version --features --json
 specify check
+specify integration status
+specify extension list
+specify workflow info speckit
 ```
 
 - `specify self check` looks for newer released CLI versions.
-- `specify version` confirms which persistent `specify` is on your `PATH`.
+- `specify version --features --json` confirms which persistent `specify` is on your `PATH` and which command surfaces are actually available.
 - `specify check` validates the local installation and environment.
+- `specify integration status` shows default integration, installed integrations, shared-template health, and managed-file drift.
+- `specify extension list` and `specify workflow info speckit` confirm which extension commands and bundled workflow steps are locally available.
 
 #### Upgrade the CLI Tool
 
-If you installed `specify` with `uv tool install`, upgrade it with:
+Prefer the CLI's own upgrade flow when it is available:
+
+```powershell
+specify self upgrade --dry-run
+specify self upgrade
+specify version --features --json
+```
+
+The dry run is required for this repository because Spec Kit upgrades can change managed prompts, skills, templates, and scripts. Review the proposed target version before applying it.
+
+If the self-upgrade flow is unavailable or you need to pin a specific version, use the package-manager fallback. For `uv tool install`:
 
 ```powershell
 uv tool install specify-cli --force --from git+https://github.com/github/spec-kit.git@vX.Y.Z
 ```
 
-If you installed it with `pipx`, use:
+For `pipx`:
 
 ```powershell
 pipx install --force git+https://github.com/github/spec-kit.git@vX.Y.Z
@@ -171,13 +200,15 @@ If the repository is clean in Git, you can also restore customized files afterwa
 
 #### Refresh Project Files for This Repository
 
-After upgrading the CLI and backing up customizations, refresh the repository's Spec Kit assets with the same integration style this project uses:
+After upgrading the CLI and backing up customizations, refresh the repository's Spec Kit assets with the same integration style this project uses. Prefer integration-aware refreshes over a blanket re-initialization:
 
 ```powershell
-specify init --here --force --integration copilot --script ps
+specify integration upgrade copilot --script ps
+specify integration upgrade codex --script ps
+specify integration status
 ```
 
-This updates the repository's installed Spec Kit infrastructure such as command files, templates, scripts, and shared memory content. It does **not** overwrite your governed feature work under [../../specs/](../../specs/), your source code, or your Git history.
+Only use `specify init --here --force --integration copilot --script ps` when the repository metadata must be recreated. Only use `integration upgrade --force` after reviewing the managed-file diff and deciding how local customizations will be preserved. These commands update the repository's installed Spec Kit infrastructure such as command files, templates, scripts, and shared memory content. They do **not** overwrite governed feature work under [../../specs/](../../specs/), source code, or Git history, but they can replace customized `.specify/`, prompt, or skill files.
 
 #### After the Upgrade
 
@@ -190,7 +221,7 @@ After refreshing project files:
 
 For this repository, treat upgrades as governed maintenance work: preserve local customizations, validate command availability, and avoid assuming that `--force` is safe for customized `.specify` assets unless you have a backup or a clean Git restore path.
 
-### 2.5 Multiple Integrations in the Same Project
+### 2.6 Multiple Integrations in the Same Project
 
 This repository may use more than one Spec Kit AI coding-agent integration so contributors can work with GitHub Copilot in VS Code and Codex in the Codex app, Codex CLI, or Codex IDE extension. Treat this as a portability setup, not as permission to mix agents casually inside one feature workflow.
 
@@ -206,6 +237,8 @@ specify integration list
 ```
 
 `specify integration status` reports the default integration, installed integrations, missing managed files, modified managed files, and shared template health. The command behavior is documented in Spec Kit's [Report Integration Status](https://github.github.io/spec-kit/reference/integrations.html#report-integration-status) reference.
+
+Current repository exception: `specify integration status` can exit non-zero because this checkout intentionally has both Copilot and Codex installed, while upstream metadata does not declare Copilot as multi-install safe. Treat that `unsafe-multi-install` finding as expected only when the default integration is still `copilot`, Codex remains isolated in `.agents/skills`, and there are no missing or invalid managed files. Any other status failure requires normal investigation before feature work continues.
 
 #### Install Codex Beside GitHub Copilot
 
@@ -245,8 +278,8 @@ Use the command style that belongs to the agent you are working in:
 
 | Tool | Spec Kit invocation style |
 | --- | --- |
-| GitHub Copilot | `/speckit.constitution`, `/speckit.specify`, `/speckit.plan`, `/speckit.tasks`, `/speckit.implement` |
-| Codex | `$speckit-constitution`, `$speckit-specify`, `$speckit-plan`, `$speckit-tasks`, `$speckit-implement` |
+| GitHub Copilot | `/speckit.constitution`, `/speckit.specify`, `/speckit.clarify`, `/speckit.checklist`, `/speckit.plan`, `/speckit.tasks`, `/speckit.analyze`, `/speckit.implement` plus installed extension prompts such as `/speckit.fleet.review`, `/speckit.verify-tasks.run`, and `/speckit.verify.run` |
+| Codex | `$speckit-constitution`, `$speckit-specify`, `$speckit-clarify`, `$speckit-checklist`, `$speckit-plan`, `$speckit-tasks`, `$speckit-analyze`, `$speckit-implement` plus installed extension skills such as `$speckit-architecture-guard-*`, `$speckit-security-review-*`, and verification skills |
 
 The core Spec Kit lifecycle commands are described in the official Spec Kit README under [Available Slash Commands](https://github.com/github/spec-kit#available-slash-commands). The naming differs because Codex uses Spec Kit skills mode while Copilot uses slash-command prompts.
 
@@ -614,7 +647,7 @@ The 18-step lifecycle below is the detailed execution model inside the SDLC loop
     - **Cross-Reference Prompt Hint**:
       > *Prompt Hint*: "Drive implementation: 'Code the feature following the generated plan. Strictly conform to interface constraints in [openapi.yaml](../openapi.yaml) and design conventions in [backend/TECHNICAL_DESIGN.md](../domains/backend/TECHNICAL_DESIGN.md).'"
 
-13. **`speckit.verify-tasks`**: Detect phantom completions and verify that tasks marked complete correspond to actual implemented work.
+13. **`speckit.verify-tasks.run`**: Detect phantom completions and verify that tasks marked complete correspond to actual implemented work.
     - **Mapped Long-Lived Documents**:
       - Feature tasks in `tasks.md`
     - **Cross-Reference Prompt Hint**:
@@ -684,7 +717,7 @@ flowchart TB
   end
 
   subgraph F3["⚙️ Delivery and Verification"]
-    S12["12 · speckit.implement"] --> S13["13 · speckit.verify-tasks"]
+    S12["12 · speckit.implement"] --> S13["13 · speckit.verify-tasks.run"]
     S13 --> S14["14 · speckit.verify.run"]
   end
 
@@ -824,8 +857,33 @@ The repository still contains older lifecycle terminology in some places. Use th
 | `speckit.validate` | `speckit.validate` alias for `speckit.speckit-utils.validate` |
 | `speckit.review` | typically handled as `speckit.fleet.review` in this repository |
 | `speckit.verify` | `speckit.verify.run` |
+| `speckit.verify-tasks` | `speckit.verify-tasks.run` |
+| `speckit.sync` or `speckit.sync.analyze` | not installed/enabled today; use `python scripts/sync_spec_status.py --gate` plus manual or skill-assisted doc promotion |
+| `speckit.converge` | official upstream convergence concept, upgrade-gated here until the CLI and local managed prompts/skills expose it; current closeout is `speckit.verify-tasks.run`, `speckit.verify.run`, sync gate, and documentation promotion |
 | `speckit.tests` | repository test execution plus traceability refresh, not a single core Spec Kit command |
 | `speckit.maintain` | maintenance stage name, not a single installed core command |
+
+### 3.6 Feature Status Taxonomy
+
+Use the status names below in feature `spec.md` headers, reviews, traceability notes, and sync discussions. Status names should describe the lifecycle state of the feature directory, not optimism about future work.
+
+| Status | Meaning | Required evidence |
+|--------|---------|-------------------|
+| `Draft` | Initial spec exists but clarification is incomplete or the feature has not reached a governed quality gate | `spec.md` exists and may still contain unresolved questions. |
+| `Clarified` | Major ambiguity has been resolved and the spec is ready for planning | `spec.md` records clarification decisions; no blocking `NEEDS CLARIFICATION` remains for the approved scope. |
+| `Planned` | Implementation approach is accepted but delivery is not complete | `plan.md` exists and constitution/technical context checks are recorded. |
+| `Implemented` | Tasks are complete and implementation evidence exists, but final verification marker is not present | `tasks.md` is complete; implementation, review, or verify-task evidence exists; `.verify-done` may be absent. |
+| `Verified` | Implementation has passed the post-implementation gate | `review.md` exists, `.verify-done` exists, task completion is complete, and the sync gate reports `current`. |
+| `Backfilled` | Spec was created after existing behavior to restore governance coverage | The spec names the source implementation evidence and must be reconciled through analysis and sync before it becomes normal planned/implemented work. |
+| `Superseded` | Feature directory is retained for history but replaced by another spec or governed artifact | `spec.md` links the replacement and explains whether traceability moved or remains historical. |
+
+Status movement rules:
+
+- Update the `**Status**` field in `spec.md` when the feature moves between these lifecycle states.
+- Create or update `review.md` during implementation verification; create `.verify-done` only after the post-implementation verification gate passes.
+- Regenerate [spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) with `python scripts/sync_spec_status.py --gate` after status, tasks, review, or SRS mapping changes.
+- Use `Implemented`, not `Verified`, when implementation evidence is complete but `.verify-done` is absent.
+- Use `Backfilled` for governance restoration of pre-existing behavior; do not use it for a normal feature that is merely late in updating docs.
 
 ## 4. Repository Artifact Authority
 
@@ -847,7 +905,7 @@ Spec Kit extensions are managed through the `specify` CLI and repository configu
 
 | Path | Purpose |
 |------|---------|
-| [../../.specify/integration.json](../../.specify/integration.json) | Declares the default integration and script style. This repository is set up for GitHub Copilot with PowerShell-oriented scripts. |
+| [../../.specify/integration.json](../../.specify/integration.json) | Declares the default integration, installed integrations, metadata version, and script style. This repository currently defaults to GitHub Copilot with PowerShell-oriented scripts while also carrying Codex skills for portability. |
 | [../../.specify/extensions.yml](../../.specify/extensions.yml) | Defines extension hooks before and after key lifecycle commands. |
 | [../../.specify/extension-catalogs.yml](../../.specify/extension-catalogs.yml) | Lists the official and community extension catalogs. |
 | [../../.specify/extensions/](../../.specify/extensions/) | Stores extension packages, prompts, configs, and command assets used by the repository. |
@@ -887,15 +945,17 @@ The repository's configured extension hooks form an operating overlay around the
 | Before `tasks` | optional commit, memory loading | Keep task generation grounded in current state |
 | After `tasks` | requirements validation, fleet review, architecture follow-up | Strengthen readiness before implementation |
 | Before `implement` | optional commit, memory loading | Reduce context loss before code generation |
-| After `implement` | verify-tasks, verify.run, architecture review | Confirm real delivery and post-implementation compliance |
+| After `implement` | verify-tasks.run, verify.run, architecture review | Confirm real delivery and post-implementation compliance |
 
 When documenting or adjusting this automation, prefer what is actually configured in [../../.specify/extensions.yml](../../.specify/extensions.yml) over generic examples from older Spec Kit material.
+
+The current supported synchronization posture is local-script first: regenerate forward and reverse traceability with `python scripts/sync_spec_status.py --gate`. Do not document `speckit.sync.*` as an available command surface until `specify extension list` shows the sync extension installed and enabled.
 
 ## 6. Best Practices
 
 - Create and maintain governed feature artifacts under [../../specs/](../../specs/), not under `docs/` and not as the primary record in `.specify/specs/`.
 - Keep [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml) synchronized whenever SRS scope changes.
-- Keep [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) aligned with actual feature status and evidence.
+- Keep [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) aligned with actual feature status and evidence by running `python scripts/sync_spec_status.py --gate` after traceability, status, or review changes.
 - Treat the project constitution in [../../.specify/memory/constitution.md](../../.specify/memory/constitution.md) as binding when reviewing or implementing work.
 - Use [../../docs/openapi.yaml](../../docs/openapi.yaml) as a mandatory synchronization target for REST API changes.
 - Prefer current official documentation links from `https://github.github.io/spec-kit/` over older repository blob links.
@@ -906,9 +966,9 @@ When documenting or adjusting this automation, prefer what is actually configure
 
 - **`specify` is not available**: install the CLI with `uv tool install` or use one-shot execution with `uvx --from git+https://github.com/github/spec-kit.git specify ...`.
 - **A command does not appear in the agent**: run `specify extension list`, confirm the related extension is available locally, and review [../../.specify/extensions.yml](../../.specify/extensions.yml).
-- **The integration looks wrong**: run `specify integration list`; this repository expects GitHub Copilot with PowerShell-oriented scripts.
+- **The integration looks wrong**: run `specify integration status` and `specify integration list`; this repository expects GitHub Copilot as default, Codex as an installed secondary integration, and PowerShell-oriented scripts.
 - **Unsure where to place new feature artifacts**: publish governed work in [../../specs/](../../specs/). Treat `.specify/` as supporting automation and template infrastructure.
-- **Traceability is stale**: update [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml), refresh task and review evidence, then bring [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) back in line.
+- **Traceability is stale**: update [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml), refresh task and review evidence, then run `python scripts/sync_spec_status.py --gate` to bring [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) back in line.
 - **REST behavior changed but documentation did not**: update [../../docs/openapi.yaml](../../docs/openapi.yaml) as part of the same delivery cycle.
 - **Mermaid does not render cleanly**: keep diagrams in fenced `mermaid` blocks and use short labels with simple punctuation.
 

--- a/docs/study-hub/project-documentation-and-specification-methodology.md
+++ b/docs/study-hub/project-documentation-and-specification-methodology.md
@@ -25,7 +25,7 @@ The current recommendation is:
 - keep **ADRs** as decision records rather than requirement documents
 - keep **OpenAPI** and other contract artifacts as executable interface sources of truth rather than duplicating them in prose
 - keep **feature specs** under `specs/` as delivery-scoped realization artifacts linked back to approved requirement IDs, following the 18-step SDD lifecycle
-- maintain **automated traceability** through `spec-traceability.yaml`, `sync_spec_status.py`, and spec-kit sync extensions to detect and resolve drift
+- maintain **automated traceability** through `spec-traceability.yaml`, `sync_spec_status.py`, and any future governed sync extension adoption to detect and resolve drift
 
 This proposal is intentionally designed to be the next-step input for generating the future project documentation set. It does not attempt to rewrite the current document corpus. Instead, it defines the target structure, the SDD lifecycle integration, the governance model, and the document boundaries needed to guide the next documentation-generation phase.
 
@@ -97,7 +97,7 @@ This means:
 - ADRs that explain architecturally significant decisions, not functional scope
 - contract artifacts owned by the relevant domain that define interfaces directly, without unnecessary prose duplication
 - feature specs that remain delivery-scoped and traceable to stable requirement IDs
-- **automated traceability** (spec-traceability.yaml, sync_spec_status.py, speckit.sync) as the mechanism that keeps documentation and code aligned
+- **automated traceability** (`spec-traceability.yaml`, `sync_spec_status.py`, and verified doc promotion) as the current mechanism that keeps documentation and code aligned
 
 Throughout this proposal, the units grouped under `docs/domains/` are better understood as **bounded contexts or delivery domains**, not technology stacks. The repository path is retained for brevity, but terms such as frontend, backend, agent, and data should be read as ownership domains or layers rather than as references to React, Flask, LangGraph, or similar implementation stacks.
 
@@ -206,13 +206,15 @@ The project has established an 18-step SDD lifecycle that governs all feature de
 | 8 | Task generation | `speckit.tasks` | Create tasks.md with user-story-organized implementation tasks |
 | 9 | Validation | `speckit.validate` | Verify spec-to-task traceability and file integrity |
 | 10 | Analysis | `speckit.analyze` | Cross-artifact consistency and quality analysis |
-| 11 | Review | `speckit.review` | Cross-model evaluation of plan and tasks before implementation |
+| 11 | Review | `speckit.fleet.review` | Cross-model evaluation of plan and tasks before implementation |
 | 12 | Implementation | `speckit.implement` | Execute tasks; code changes aligned to spec and plan |
-| 13 | Task verification | `speckit.verify-tasks` | Detect phantom completions; verify code exists for every checked task |
-| 14 | Post-implementation verification | `speckit.verify` | Validate implementation against spec, plan, tasks, and constitution |
-| 15 | Testing and traceability | Manual + sync | Run tests; update spec-traceability.yaml with gate status |
-| 16 | Maintenance | `speckit.sync` | Detect and resolve spec-to-code drift; backfill unspecced code |
+| 13 | Task verification | `speckit.verify-tasks.run` | Detect phantom completions; verify code exists for every checked task |
+| 14 | Post-implementation verification | `speckit.verify.run` | Validate implementation against spec, plan, tasks, and constitution |
+| 15 | Testing and traceability | Manual + `scripts/sync_spec_status.py --gate` | Run tests; update spec-traceability.yaml with gate status and regenerate forward/reverse reports |
+| 16 | Maintenance | `scripts/sync_spec_status.py --gate` plus manual or skill-assisted promotion | Detect and resolve spec-to-code drift; backfill unspecced code when needed |
 | 17 | Documentation sync | Manual | Synchronize long-lived docs affected by the delivered feature |
+
+Command-surface rule: this methodology names the current local command surfaces. Older shorthand such as `speckit.review`, `speckit.verify`, and `speckit.sync` may appear in historical notes, but new process guidance should use `speckit.fleet.review`, `speckit.verify.run`, and `scripts/sync_spec_status.py --gate`. Upstream-only concepts such as `speckit.converge` are upgrade-gated here until the CLI and local managed prompt/skill files expose them.
 
 ### 7.2 How SDD Connects to System Documentation
 
@@ -226,7 +228,7 @@ The SDD lifecycle connects delivery-scoped artifacts (`specs/`) to long-lived sy
 
 4. **Post-delivery documentation sync**: Step 17 is where the SDD lifecycle feeds back into long-lived documentation. When a feature changes API behavior, the OpenAPI contract must be updated (Constitution Golden Rule 9). When a feature introduces new architectural patterns, ADRs are created. When a feature covers new SRS territory, the traceability summary is updated.
 
-5. **Drift detection**: Step 16 (`speckit.sync`) identifies when code has diverged from specs, when specs have diverged from SRS, or when code exists without spec coverage. This is the automated maintenance mechanism for the documentation set.
+5. **Drift detection**: Step 16 currently uses `scripts/sync_spec_status.py --gate` for requirement-to-spec status and manual or skill-assisted review for code-to-doc drift. The `speckit.sync.*` surface is not installed/enabled today; if adopted later, it should supplement the local script rather than replace the manifest/report authority without a governed migration.
 
 ### 7.3 SRS as Upstream Requirement Pool
 
@@ -254,6 +256,16 @@ That translates into these practical operating rules:
 5. **Use executable artifacts as the contract source of truth.** If `openapi.yaml`, code-level schemas, or test contracts already express the interface, prose should explain obligations and rationale, not restate the contract.
 6. **Create subordinate SRS documents only when the domain has sustained change pressure.** In this repository that likely means agent, frontend, and operations first; API and data should only gain separate requirement documents when repeated cross-feature obligations justify them.
 7. **Promote requirement-level content after verification, not before.** SRS documents and requirement baselines should be updated after a feature passes implementation and verification, so the requirement record reflects proven behavior rather than planned intent. However, technical design documents and ADRs may be updated earlier in the lifecycle to communicate architectural direction to concurrent work — these serve as coordination tools, not just records of what was built.
+
+#### Spec Persistence Policy
+
+The repository uses Spec Kit persistence deliberately rather than treating every generated artifact the same way.
+
+- **Living specs for active work**: while a feature is being clarified, planned, implemented, or verified, `spec.md`, `plan.md`, and `tasks.md` remain living artifacts. If implementation discovers a requirement or design issue, update the active artifacts and rerun analysis/sync before continuing.
+- **Flow-forward after verification**: once a feature directory is verified, treat it as delivery evidence. Promote stable knowledge into `docs/`, contracts, traceability, roadmap, or ADRs instead of repeatedly rewriting the historical feature directory.
+- **Flow-back only during active implementation**: updates from code back into `spec.md` or `plan.md` are allowed while the feature is active, but they must pass an analysis/sync reconciliation gate so the feature directory, tasks, traceability, and long-lived docs remain aligned.
+- **Backfill as restoration, not normal delivery**: use `Backfilled` only when restoring governance coverage for behavior that already exists. A backfilled spec must name source evidence and then move through reconciliation before it is treated like planned or implemented SDD work.
+- **Supersede instead of mutating history**: if verified behavior changes materially later, create a follow-up feature spec or governed doc update, link the old spec as superseded, and move traceability intentionally.
 
 ### 7.5 SRS Lifecycle During Development
 
@@ -299,14 +311,15 @@ The SDD practice uses a chain of quality gates enforced through spec-kit extensi
 | Gate | Extension | When Applied | What It Catches |
 |------|-----------|--------------|-----------------|
 | Spec quality | `speckit.understanding.validate` | After specify | Ambiguity, untestability, structural weakness (31 metrics, ISO 29148 gates) |
-| Project health | `speckit.doctor` | Before plan | Missing templates, broken config, stale artifacts |
+| Project health | `speckit.doctor` / `speckit.speckit-utils.doctor` | Before plan | Missing templates, broken config, stale artifacts |
 | Constitution compliance | `speckit.plan` (constitution check) | Before and after planning | Violations of core principles or golden rules |
-| Traceability completeness | `speckit.validate` | After tasks | Unmapped requirements, orphaned tasks, missing files |
+| Traceability completeness | `speckit.validate` / `speckit.speckit-utils.validate` | After tasks | Unmapped requirements, orphaned tasks, missing files |
 | Cross-artifact consistency | `speckit.analyze` | After tasks | Contradictions between spec, plan, and tasks |
-| Cross-model review | `speckit.review` | Before implement | Blind spots, feasibility gaps, risk assessment |
-| Phantom completion detection | `speckit.verify-tasks` | After implement | Tasks marked done but code missing or dead |
-| Post-implementation verification | `speckit.verify` | After implement | Gaps between implemented code and spec/plan/tasks/constitution |
-| Drift detection | `speckit.sync.analyze` | During maintenance | Code-to-spec divergence, unspecced features, inter-spec contradictions |
+| Cross-model review | `speckit.fleet.review` | Before implement | Blind spots, feasibility gaps, risk assessment |
+| Phantom completion detection | `speckit.verify-tasks.run` | After implement | Tasks marked done but code missing or dead |
+| Post-implementation verification | `speckit.verify.run` | After implement | Gaps between implemented code and spec/plan/tasks/constitution |
+| Traceability and sync gate | `scripts/sync_spec_status.py --gate` | During maintenance | SRS baseline mismatch, feature status drift, stale forward/reverse reports |
+| Code-to-document drift review | Manual or skill-assisted review, typically `$technical-design-manager` for technical design promotion | During maintenance | Code-to-spec divergence, unspecced behavior, long-lived doc promotion gaps |
 
 These gates apply to feature-level work today. As system-level documentation is generated, the same governance model should extend to long-lived documents through periodic sync analysis and constitution-aware authoring.
 
@@ -319,6 +332,8 @@ The project maintains automated traceability through three interconnected artifa
 2. **`specs/spec-sync-status.md`** — Human-readable summary report showing feature mapping status, coverage, linked SRS items, and evidence links.
 
 3. **`scripts/sync_spec_status.py`** — CLI automation that generates forward and reverse traceability reports from the YAML manifest.
+
+Sync extension posture: `speckit.sync.*` is not installed or enabled in the current repository command surface. The supported operating path is the local script plus manual or skill-assisted promotion into long-lived docs. If a future upgrade adopts the sync extension, it should be documented as a governed change with command availability confirmed by `specify extension list`, not inferred from upstream examples.
 
 When the system-level SRS is created, the traceability registry should be extended to track:
 
@@ -416,6 +431,8 @@ This is the recommended compact domain model for this repository. The important 
 - domain folders do not need symmetric document sets; each domain only grows when repeated delivery pressure justifies it
 - delivery detail stays in `specs/`, so these domain folders hold stable design and specialized obligations rather than feature-by-feature change history
 
+Current-vs-target contract note: the target tree shows backend-owned API contract placement, but the current canonical REST contract is still `docs/openapi.yaml`. Do not move or replace it until a governed migration updates every reference and validation path.
+
 ### 9.2 Purpose and Standards Stance by Document Type
 
 Each document type has both a standards stance and a notation policy. The standards stance describes how the artifact relates to external standards; Section 9.3 defines the diagram and notation rules that keep visuals consistent across the documentation set.
@@ -428,7 +445,7 @@ Each document type has both a standards stance and a notation policy. The standa
 | **ADRs** | `docs/architecture/DECISIONS/` and `docs/domains/*/DECISIONS/` | Capture architecturally significant decisions and tradeoffs at system or domain scope | **Practice-Based** ADR discipline |
 | **Domain Technical Design** | `docs/domains/*/TECHNICAL_DESIGN.md` | Explains how each domain realizes the requirements allocated to it and records domain-specific constraints that do not belong in the system-level architecture documents | **Aligned** design practice |
 | **Domain-Specific Requirement Documents** | only where justified, for example `docs/domains/agent/SOFTWARE_REQUIREMENTS_SPECIFICATION.md` | Holds subordinate requirement sets only when a bounded context is independently complex, specialized, or already mature enough to need its own requirement baseline | **Aligned** subordinate SRS practice |
-| **Executable Contracts** | domain-owned artifacts such as `docs/domains/backend/api/openapi.yaml` | Defines request/response schemas, event contracts, and integration payloads without duplicating them in prose | **Conformant** to schema or contract standards |
+| **Executable Contracts** | current canonical REST contract: `docs/openapi.yaml`; target domain-owned path after governed migration: `docs/domains/backend/api/openapi.yaml` | Defines request/response schemas, event contracts, and integration payloads without duplicating them in prose | **Conformant** to schema or contract standards |
 | **Operations Policy and Runbooks** | `docs/operations/OPERATIONS_AND_RELEASE_POLICY.md`, `docs/operations/RUNBOOKS/` | Defines supportability, release readiness, migration, reconciliation, rollback, and incident handling expectations | **Aligned** for policy; **Practice-Based** for runbooks |
 | **Verification and Traceability Strategy** | `docs/testing/VERIFICATION_AND_TRACEABILITY_STRATEGY.md` | Defines test levels, evidence expectations, and how requirements are proven through specs and tests | **Aligned** internal verification standard |
 | **Study and Analysis Documents** | `docs/study-hub/` | Holds research, comparison studies, and planning proposals that inform decisions but are not themselves long-lived authority documents | **Practice-Based** study format |
@@ -599,7 +616,7 @@ The examples below show how domain allocation should work in practice.
 | Priority | P0 |
 | Primary Owning Domain | backend |
 | Contributing Domains | frontend, agent |
-| Linked Domain Documents / Contracts | `docs/domains/backend/TECHNICAL_DESIGN.md`, `docs/domains/frontend/TECHNICAL_DESIGN.md`, `docs/domains/backend/api/openapi.yaml` |
+| Linked Domain Documents / Contracts | `docs/domains/backend/TECHNICAL_DESIGN.md`, `docs/domains/frontend/TECHNICAL_DESIGN.md`, current `docs/openapi.yaml` contract; future `docs/domains/backend/api/openapi.yaml` after governed migration |
 | Spec Coverage Status | mapped via feature spec(s) in `specs/` |
 
 **Example Non-Functional Requirement**
@@ -668,7 +685,7 @@ The frontend domain should gain a `TECHNICAL_DESIGN.md` before it gains a subord
 
 #### 11.4.3 Backend Domain
 
-The backend domain should own both its internal realization and its external API contracts. Under the target model, the current [OpenAPI Specification](../openapi.yaml) maps conceptually to `docs/domains/backend/api/openapi.yaml`.
+The backend domain should own both its internal realization and its external API contracts. The current canonical REST contract remains [OpenAPI Specification](../openapi.yaml). The target model may move that contract to `docs/domains/backend/api/openapi.yaml`, but only through a governed migration that updates references, traceability, CI checks, and contributor guidance in one change set.
 
 The backend domain technical design should explain route, service, and integration layering. It should not duplicate API contract schemas that already live in OpenAPI.
 
@@ -698,7 +715,7 @@ Generate or stabilize only the documents that the rest of the SDD workflow depen
 2. `docs/system/SYSTEM_REQUIREMENTS_SPECIFICATION.md` — The upstream requirement pool for cross-domain requirements.
 3. `docs/architecture/SYSTEM_OVERVIEW_AND_BOUNDARIES.md` — Whole-system static view and domain boundaries.
 4. `docs/architecture/RUNTIME_AND_INTEGRATION_FLOWS.md` — Whole-system runtime flows across frontend, backend, agent, data, and operations concerns.
-5. `docs/domains/backend/api/openapi.yaml` — The executable backend API contract, initially sourced from the current `docs/openapi.yaml`.
+5. `docs/openapi.yaml` — The current executable backend API contract; `docs/domains/backend/api/openapi.yaml` is the target location only after a governed migration.
 
 **SDD integration**: Extend `spec-traceability.yaml` to support system-level requirement IDs (SR-x, SNR-x) alongside the existing domain-level IDs (FR-x, NFR-x).
 
@@ -708,7 +725,7 @@ Do not generate parallel replacements for documents the repository already maint
 
 1. Reclassify the current `docs/langchain-agent/` material into the future `docs/domains/agent/` ownership model.
 2. Reclassify the current frontend ADRs into the future `docs/domains/frontend/DECISIONS/` ownership model.
-3. Reclassify the current `docs/openapi.yaml` into the future `docs/domains/backend/api/openapi.yaml` ownership model.
+3. Reclassify the current `docs/openapi.yaml` into the future `docs/domains/backend/api/openapi.yaml` ownership model only after a governed migration plan exists.
 
 This phase is mostly classification, not content generation.
 
@@ -730,7 +747,7 @@ As features are delivered, promote only stable, repeated knowledge from `specs/`
 
 1. stable requirements into the master or subordinate SRS
 2. stable decisions into ADRs
-3. stable contracts into domain-owned executable artifacts such as `docs/domains/backend/api/openapi.yaml`
+3. stable contracts into the current executable contract at `docs/openapi.yaml`, or into future domain-owned executable artifacts such as `docs/domains/backend/api/openapi.yaml` after migration
 4. stable operating procedures into runbooks
 5. stable diagrams into the target long-lived document only after they have been normalized to the notation policy for that document type
 
@@ -782,3 +799,4 @@ The practical recommendation is to keep `docs/` small, keep `specs/` rich, and p
 | 0.7 | 2026-04-03 | GitHub Copilot | Resolved remaining glossary drift by aligning the target file tree back to `docs/domains/`, correcting lifecycle wording to the 18-step SDD lifecycle consistently, and adding an explicit API Boundary / API Contract glossary entry to clarify that API is a backend domain boundary rather than a separate ownership domain |
 | 0.8 | 2026-05-27 | GitHub Copilot | Added a document-type notation policy and explicit diagram visualization quality rules covering diagram scope statements, state labeling, readable flow direction, legend discipline, accessibility of meaning without color, and when to split visuals or pair them with tables |
 | 0.9 | 2026-05-28 | GitHub Copilot | Added a discoverability pointer to the documentation-focused custom agent and aligned related-document guidance with the repository's Spec Kit HOW-TO and documentation maintenance workflow |
+| 1.0 | 2026-07-01 | Codex | Aligned methodology with current local Spec Kit command surfaces, documented spec persistence policy, clarified sync-extension posture, and preserved `docs/openapi.yaml` as the current canonical contract until governed migration |

--- a/scripts/sync_spec_status.py
+++ b/scripts/sync_spec_status.py
@@ -14,7 +14,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_MANIFEST = ROOT / "specs" / "spec-traceability.yaml"
 DEFAULT_OUTPUT = ROOT / "specs" / "spec-sync-status.md"
-DEFAULT_REVERSE_OUTPUT = ROOT / "docs" / "langchain-agent" / "SRS_SPEC_TRACEABILITY.md"
+DEFAULT_REVERSE_OUTPUT = ROOT / "docs" / "domains" / "agent" / "SRS_SPEC_TRACEABILITY.md"
 
 
 TASK_PATTERN = re.compile(r"^- \[(?P<mark>[ xX])\] (?P<task>T\d+)\b")
@@ -289,10 +289,10 @@ def render_report(manifest: Dict[str, Any], results: List[FeatureSyncResult], ou
     lines: List[str] = []
     lines.append("# Spec Sync Status")
     lines.append("")
-    lines.append(f"> **Document Version**: {report_metadata.get('version', '1.0')}  ")
-    lines.append(f"> **Generated**: {generated_at}  ")
-    lines.append(f"> **Status**: {report_metadata.get('status', 'Active')}  ")
-    lines.append(f"> **Traceability Manifest Version**: {manifest.get('version', 'n/a')}  ")
+    lines.append(f"> **Document Version**: {report_metadata.get('version', '1.0')}")
+    lines.append(f"> **Generated**: {generated_at}")
+    lines.append(f"> **Status**: {report_metadata.get('status', 'Active')}")
+    lines.append(f"> **Traceability Manifest Version**: {manifest.get('version', 'n/a')}")
     lines.append("")
     lines.append("## Baseline")
     lines.append("")
@@ -351,7 +351,7 @@ def render_report(manifest: Dict[str, Any], results: List[FeatureSyncResult], ou
     lines.append("")
     lines.append("- Update `spec-traceability.yaml` when a feature gains or changes SRS scope.")
     lines.append("- Update `tasks.md` and workflow markers during delivery.")
-    lines.append("- Regenerate this report with `python scripts/sync_spec_status.py` whenever either side changes.")
+    lines.append("- Regenerate this report with `python scripts/sync_spec_status.py --gate` whenever either side changes.")
     lines.append("")
     return "\n".join(lines)
 
@@ -366,10 +366,10 @@ def render_reverse_trace(manifest: Dict[str, Any], results: List[FeatureSyncResu
     lines: List[str] = []
     lines.append("# SRS To Spec Traceability")
     lines.append("")
-    lines.append(f"> **Document Version**: {report_metadata.get('version', '1.0')}  ")
-    lines.append(f"> **Generated**: {generated_at}  ")
-    lines.append(f"> **Status**: {report_metadata.get('status', 'Active')}  ")
-    lines.append(f"> **Traceability Manifest Version**: {manifest.get('version', 'n/a')}  ")
+    lines.append(f"> **Document Version**: {report_metadata.get('version', '1.0')}")
+    lines.append(f"> **Generated**: {generated_at}")
+    lines.append(f"> **Status**: {report_metadata.get('status', 'Active')}")
+    lines.append(f"> **Traceability Manifest Version**: {manifest.get('version', 'n/a')}")
     lines.append("")
     lines.append("## Baseline")
     lines.append("")

--- a/specs/prompt-system-milestone1/spec.md
+++ b/specs/prompt-system-milestone1/spec.md
@@ -4,7 +4,7 @@
 
 **Created**: 2026-06-03
 
-**Status**: Draft
+**Status**: Implemented
 
 **Input**: Milestone M1 from [PHASE_2_AGENT_ENHANCEMENT_ROADMAP.md §2A.2 Prompt Compiler Path & Controlled Rollout](../../docs/domains/agent/PHASE_2_AGENT_ENHANCEMENT_ROADMAP.md#2a2-prompt-compiler-path--controlled-rollout), backlog items `PS-01` through `PS-06` from the [Execution Backlog Mirror](../../docs/domains/agent/PHASE_2_AGENT_ENHANCEMENT_ROADMAP.md#execution-backlog-mirror-synced-to-proposal-v18), and the governing SRS sections in [SOFTWARE_REQUIREMENTS_SPECIFICATION.md](../../docs/domains/agent/SOFTWARE_REQUIREMENTS_SPECIFICATION.md).
 

--- a/specs/prompt-system-milestone2/spec.md
+++ b/specs/prompt-system-milestone2/spec.md
@@ -6,7 +6,7 @@
 
 **Created**: 2026-06-04
 
-**Status**: Draft
+**Status**: Implemented
 
 **Input**: Milestone M2 from [PHASE_2_AGENT_ENHANCEMENT_ROADMAP.md §2A.2 Prompt Compiler Path & Controlled Rollout](../../docs/domains/agent/PHASE_2_AGENT_ENHANCEMENT_ROADMAP.md#2a2-prompt-compiler-path--controlled-rollout), backlog items `PS-07` and `PS-08`.
 

--- a/specs/spec-sync-status.md
+++ b/specs/spec-sync-status.md
@@ -1,35 +1,37 @@
 # Spec Sync Status
 
-> **Document Version**: 1.0  
-> **Generated**: 2026-03-20 07:30:26Z  
-> **Status**: Active  
-> **Traceability Manifest Version**: 1  
+> **Document Version**: 1.5
+> **Generated**: 2026-07-01 04:02:48Z
+> **Status**: Active
+> **Traceability Manifest Version**: 1
 
 ## Baseline
 
 - SRS: [docs/domains/agent/SOFTWARE_REQUIREMENTS_SPECIFICATION.md](../docs/domains/agent/SOFTWARE_REQUIREMENTS_SPECIFICATION.md)
-- SRS version: `2.3`
-- SRS last updated: `2026-04-13`
+- SRS version: `2.7`
+- SRS last updated: `2026-06-03`
 
 ## Summary
 
 | Feature | Mapping | Coverage | Derived Status | Sync Status | Tasks |
 |---------|---------|----------|----------------|-------------|-------|
 | [agent-session-with-stm-wiring](agent-session-with-stm-wiring/spec.md#requirements-mandatory) | `mapped` | `partial` | `verified` | `current` | `32/32` |
-| [stm-phase-cde](stm-phase-cde/spec.md#requirements-mandatory) | `mapped` | `partial` | `clarified` | `current` | `n/a` |
+| [stm-phase-cde](stm-phase-cde/spec.md#requirements-mandatory) | `mapped` | `partial` | `verified` | `current` | `56/56` |
 | [001-stm-domain-service-refactor](001-stm-domain-service-refactor/plan.md) | `unmapped` | `n/a` | `unmapped` | `unmapped` | `n/a` |
 | [spec-driven-development-pilot](spec-driven-development-pilot/plan.md#summary) | `mapped` | `partial` | `implemented` | `current` | `42/42` |
-| [prompt-system-milestone1](prompt-system-milestone1/spec.md#requirements-mandatory) | `mapped` | `partial` | `implemented` | `current` | `42/42` |
-| [prompt-system-milestone2](prompt-system-milestone2/spec.md#governance-context-mandatory) | `mapped` | `partial` | `planned` | `current` | `n/a` |
+| [prompt-system-milestone1](prompt-system-milestone1/spec.md#user-scenarios--testing-mandatory) | `mapped` | `partial` | `implemented` | `current` | `42/42` |
+| [prompt-system-milestone2](prompt-system-milestone2/spec.md#governance-context-mandatory) | `mapped` | `partial` | `implemented` | `current` | `45/45` |
 
 ## Revision History
 
 | Version | Date | Summary |
 |---------|------|---------|
 | `1.0` | `2026-03-19` | Added embedded report metadata and anchor-aware evidence links for forward spec sync reporting. |
-| `1.1` | `2026-06-03` | Added prompt-system-milestone1 (M1) delivery entry — implementation tasks complete (42/42), 29/29 tests passing, core components delivered, all test and doc sync tasks complete. SRS baseline updated to v2.7. |
-| `1.2` | `2026-06-04` | Added prompt-system-milestone2 (M2) entry — spec and quality checklist created, route-aware skills specification drafted. Mapping status: planned. |
-| `1.3` | `2026-06-04` | Updated M2 to implemented — PromptAssembler, 8 route-skill assets, agent wiring, config extension, and verification complete. 26/29 M1 tests pass (3 pre-existing mocker fixture gaps), 45/45 tasks complete. |
+| `1.1` | `2026-03-31` | Synchronized stm-phase-cde from clarified planning state to verified implementation state and expanded evidence links. |
+| `1.2` | `2026-06-03` | Updated prompt-system-milestone1 mapping_status to implemented, added tasks.md/checklists/verify-tasks-report.md/review.md to evidence paths. Task completion 42/42, tests 29/29. |
+| `1.3` | `2026-06-04` | Added prompt-system-milestone2 (M2) feature entry — mapping_status planned, spec.md and quality checklist as evidence paths. SRS v2.7 baseline reused. |
+| `1.4` | `2026-06-04` | Updated prompt-system-milestone2 (M2) feature entry — mapping_status implemented, all design and delivery artifacts added to evidence paths. PromptAssembler, route-skill assets, and agent wiring delivered. |
+| `1.5` | `2026-07-01` | Normalized feature mapping_status values back to mapped, aligned legacy STM feature baselines to SRS v2.7, and expanded M2 evidence paths for regenerated sync reports. |
 
 ## agent-session-with-stm-wiring
 
@@ -63,13 +65,21 @@
 - Path: [specs/stm-phase-cde](stm-phase-cde/spec.md#requirements-mandatory)
 - Mapping status: `mapped`
 - Coverage status: `partial`
-- Derived status: `clarified`
+- Derived status: `verified`
 - Sync status: `current`
 - Sync gate enforced: `yes`
-- spec.md status field: `Clarified`
+- spec.md status field: `Verified`
+- Task completion: `56/56`
 - Linked SRS items: `FR-3.1.3, FR-3.2.2, FR-3.2.3, FR-3.2.6, FR-3.2.7, FR-3.2.8, FR-3.2.10, FR-5.1.7, FR-5.1.8, FR-5.3.1, FR-5.3.2, FR-5.3.3, FR-5.3.4, FR-5.3.5, FR-5.3.6, FR-5.4.1, FR-5.4.2, FR-5.4.3, FR-5.4.4, FR-5.4.5, FR-5.4.6, FR-5.4.7, FR-5.4.8, FR-5.5.1, FR-5.5.2, FR-5.5.3, FR-5.5.4, FR-5.5.5, FR-5.5.6, FR-5.6.1, FR-5.6.2, FR-5.6.3, FR-5.6.4, FR-5.6.5, FR-7.1.1, FR-7.1.2, FR-7.1.3, FR-7.1.4, FR-7.1.5, FR-7.2.1, FR-7.2.2, FR-7.2.3, FR-7.2.4, FR-7.2.5, FR-7.3.1, FR-7.3.2, FR-7.3.3, FR-7.3.4, FR-7.3.5, FR-7.3.6, NFR-1.4.1, NFR-1.4.2, NFR-1.4.3, NFR-1.4.4, NFR-2.3.2, NFR-2.4.1, NFR-2.4.2, NFR-2.4.3, NFR-2.4.4, NFR-2.4.5, NFR-2.5.1, NFR-2.5.2, NFR-2.5.3, NFR-2.5.4, NFR-6.1.3, AC-2.2, AC-2.5, AC-2.6, AC-5.1, AC-5.2, AC-5.3, AC-5.4, AC-5.5, AC-5.6, AC-5.7, AC-6.1, AC-6.2, AC-6.3, AC-6.4, AC-6.5, AC-6.6, AC-7.1, AC-7.2, AC-7.3, AC-7.4, AC-7.5, IR-1.8, IR-1.9, IR-1.10, IR-1.11, IR-1.12, IR-1.13`
 - Evidence:
   - [Feature requirements](stm-phase-cde/spec.md#requirements-mandatory)
+  - [Delivery plan](stm-phase-cde/plan.md)
+  - [Task checklist](stm-phase-cde/tasks.md)
+  - [Validation runbook](stm-phase-cde/quickstart.md)
+  - [Verification review](stm-phase-cde/review.md)
+  - [Implementation sync status](stm-phase-cde/review.md#implementation-sync-status)
+  - [Analyze marker](stm-phase-cde/.analyze-done)
+  - [Verify marker](stm-phase-cde/.verify-done)
 
 ## 001-stm-domain-service-refactor
 
@@ -99,41 +109,17 @@
   - [Session-aware conversation phase](spec-driven-development-pilot/tasks.md#phase-3-us1--session-aware-conversation-p1--5-6-sp)
   - [Runtime integration phase](spec-driven-development-pilot/tasks.md#phase-9-stm-runtime-integration--agent-migration-critical--5-6-sp)
   - [STM quickstart](spec-driven-development-pilot/quickstart.md)
-  - [STM data model](spec-driven-development-pilot/data-model.md)
-  - [API contract](spec-driven-development-pilot/contracts/api-contract.yaml)
 
-## prompt-system-milestone2
+## prompt-system-milestone1
 
-- Title: Prompt Compiler Path — Milestone M2 (Route-Aware Skills)
-- Path: [specs/prompt-system-milestone2/spec.md](./prompt-system-milestone2/spec.md#governance-context-mandatory)
+- Title: Prompt Compiler Path — Milestone M1 (Prompt Runtime Parity)
+- Path: [specs/prompt-system-milestone1](prompt-system-milestone1/spec.md#user-scenarios--testing-mandatory)
 - Mapping status: `mapped`
 - Coverage status: `partial`
 - Derived status: `implemented`
 - Sync status: `current`
 - Sync gate enforced: `yes`
 - spec.md status field: `Implemented`
-- Backlog: PS-07 (Route-Context Prompt Assets), PS-08 (PromptAssembler + Route-Aware Composition)
-- Depends on: M1 complete (PromptAssetLoader, selection tuple, prompt config)
-- Tasks: `45/45`
-- SRS scope: FR-1.4.7, FR-1.4.11, FR-1.4.16, NFR-5.2.8, AC-8.5, AC-8.8, AC-8.11
-- Gate: Do not enable experiment modes until route-aware composition is stable and traceable
-
-## SRS Baseline Update
-
-The SRS baseline version is updated from `2.3` to `2.7` to reflect the latest SRS freeze (matching prompt-system-milestone1 sync). M2 uses the same v2.7 baseline.
-
-## prompt-system-milestone1
-
-(as already recorded)
-
-- Title: Prompt Compiler Path — Milestone M1 (Prompt Runtime Parity)
-- Path: [specs/prompt-system-milestone1](prompt-system-milestone1/spec.md#requirements-mandatory)
-- Mapping status: `mapped`
-- Coverage status: `partial`
-- Derived status: `implemented`
-- Sync status: `current`
-- Sync gate enforced: `yes`
-- spec.md status field: `Draft`
 - Task completion: `42/42`
 - Linked SRS items: `FR-1.4.5, FR-1.4.6, FR-1.4.8, FR-1.4.16, NFR-5.2.5, NFR-5.2.6, NFR-5.2.7, NFR-5.2.8, NFR-5.2.9, NFR-6.2.3, AC-8.1, AC-8.2`
 - Evidence:
@@ -141,7 +127,32 @@ The SRS baseline version is updated from `2.3` to `2.7` to reflect the latest SR
   - [Implementation plan](prompt-system-milestone1/plan.md)
   - [Task checklist](prompt-system-milestone1/tasks.md)
   - [Quality gate checklist](prompt-system-milestone1/checklists/spec-plan-quality.md)
-  - [Post-implementation verification](prompt-system-milestone1/verify-tasks-report.md)
+  - [Post-implementation verification report](prompt-system-milestone1/verify-tasks-report.md)
+  - [Verification review](prompt-system-milestone1/review.md)
+
+## prompt-system-milestone2
+
+- Title: Prompt Compiler Path — Milestone M2 (Route-Aware Skills)
+- Path: [specs/prompt-system-milestone2](prompt-system-milestone2/spec.md#governance-context-mandatory)
+- Mapping status: `mapped`
+- Coverage status: `partial`
+- Derived status: `implemented`
+- Sync status: `current`
+- Sync gate enforced: `yes`
+- spec.md status field: `Implemented`
+- Task completion: `45/45`
+- Linked SRS items: `FR-1.4.7, FR-1.4.11, FR-1.4.16, NFR-5.2.8, AC-8.5, AC-8.8, AC-8.11`
+- Evidence:
+  - [Feature specification](prompt-system-milestone2/spec.md#governance-context-mandatory)
+  - [Quality gate checklist](prompt-system-milestone2/checklists/requirements.md)
+  - [Implementation plan](prompt-system-milestone2/plan.md)
+  - [Task checklist](prompt-system-milestone2/tasks.md)
+  - [Research notes](prompt-system-milestone2/research.md)
+  - [Data model](prompt-system-milestone2/data-model.md)
+  - [Quickstart validation](prompt-system-milestone2/quickstart.md)
+  - [Prompt assembler contract](prompt-system-milestone2/contracts/prompt-assembler-interface.md)
+  - [Route skill asset contract](prompt-system-milestone2/contracts/route-skill-asset-schema.md)
+  - [Verification review](prompt-system-milestone2/review.md)
 
 ## Status Semantics
 
@@ -153,5 +164,5 @@ The SRS baseline version is updated from `2.3` to `2.7` to reflect the latest SR
 
 - Update `spec-traceability.yaml` when a feature gains or changes SRS scope.
 - Update `tasks.md` and workflow markers during delivery.
-- Regenerate this report with `python scripts/sync_spec_status.py` whenever either side changes.
+- Regenerate this report with `python scripts/sync_spec_status.py --gate` whenever either side changes.
 


### PR DESCRIPTION
The repo's Spec Kit guidance had drifted away from the commands, statuses, and sync surfaces that are actually installed locally. That left contributors reading upstream examples and legacy names while this checkout was using different review, verify, and traceability paths.

This reconciles the constitution, HOW-TO, methodology, and generation templates around the current local command surface, codifies feature lifecycle and spec persistence rules, and keeps docs/openapi.yaml as the canonical REST contract until a governed migration is ready.

It also updates sync reporting to use the current reverse-trace target, regenerates the status report, and aligns milestone spec statuses so the repo's delivery evidence and governance gates tell the same story.