### PR TITLE
Add doc-sync gate extension and hook it into Spec Kit workflows

### DIFF
--- a/.agents/skills/speckit-doc-sync-gate/SKILL.md
+++ b/.agents/skills/speckit-doc-sync-gate/SKILL.md
@@ -1,0 +1,1 @@
+../../../.specify/extensions/doc-sync/.specify-dev/agent-commands/zed/speckit-doc-sync-gate/SKILL.md

--- a/.github/agents/speckit.doc-sync.gate.agent.md
+++ b/.github/agents/speckit.doc-sync.gate.agent.md
@@ -1,0 +1,1 @@
+../../.specify/extensions/doc-sync/.specify-dev/agent-commands/copilot/speckit.doc-sync.gate.agent.md

--- a/.github/prompts/speckit.doc-sync.gate.prompt.md
+++ b/.github/prompts/speckit.doc-sync.gate.prompt.md
@@ -1,0 +1,3 @@
+---
+agent: speckit.doc-sync.gate
+---

--- a/.specify/extensions.yml
+++ b/.specify/extensions.yml
@@ -2,6 +2,7 @@ installed:
 - agent-context
 - arch
 - architecture-guard
+- doc-sync
 - harness
 - memory-loader
 - security-review
@@ -48,6 +49,14 @@ hooks:
     description: ''
     condition: null
   after_implement:
+  - extension: doc-sync
+    command: speckit.doc-sync.gate
+    enabled: true
+    optional: false
+    priority: 5
+    prompt: Run implementation document-spec sync gate before verification?
+    description: Refresh traceability reports from implementation evidence before verification
+    condition: null
   - extension: verify-tasks
     command: speckit.verify-tasks.run
     enabled: true
@@ -69,11 +78,19 @@ hooks:
     prompt: Run verify to validate implementation against specification?
     description: Post-implementation verification gate
     condition: null
+  - extension: doc-sync
+    command: speckit.doc-sync.gate
+    enabled: true
+    optional: false
+    priority: 50
+    prompt: Run final document-spec sync gate after verification?
+    description: Final hard sync gate before treating a feature as Verified
+    condition: null
   - extension: security-review
     command: speckit.security-review.branch
     enabled: true
     optional: true
-    priority: 10
+    priority: 60
     prompt: Would you like to scan the new implementation for security vulnerabilities?
     description: ''
     condition: null
@@ -81,7 +98,7 @@ hooks:
     command: speckit.architecture-guard.architecture-review
     enabled: true
     optional: true
-    priority: 10
+    priority: 70
     prompt: Would you like to run a post-implementation architecture review?
     description: ''
     condition: null
@@ -122,6 +139,14 @@ hooks:
     optional: true
     prompt: Validate spec-to-task traceability?
     description: Verify requirements map to planned tasks after planning
+    condition: null
+  - extension: doc-sync
+    command: speckit.doc-sync.gate
+    enabled: true
+    optional: false
+    priority: 10
+    prompt: Run document-spec sync gate after planning?
+    description: Validate planned SRS mappings and sync reports before task generation
     condition: null
   - extension: git
     command: speckit.git.commit

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -260,6 +260,29 @@
       },
       "registered_skills": [],
       "installed_at": "2026-05-21T07:20:36.956085+00:00"
+    },
+    "doc-sync": {
+      "version": "1.0.1",
+      "source": "local",
+      "manifest_hash": "sha256:0b0a0819dbc8844c58c1b70e80a239fde74245658946b7298b4216597c6ee02f",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "agy": [
+          "speckit.doc-sync.gate"
+        ],
+        "codex": [
+          "speckit.doc-sync.gate"
+        ],
+        "copilot": [
+          "speckit.doc-sync.gate"
+        ],
+        "zed": [
+          "speckit.doc-sync.gate"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-07-02T05:03:08.240888+00:00"
     }
   }
 }

--- a/.specify/extensions/.registry
+++ b/.specify/extensions/.registry
@@ -302,6 +302,29 @@
       },
       "registered_skills": [],
       "installed_at": "2026-05-21T07:20:36.956085+00:00"
+    },
+    "doc-sync": {
+      "version": "1.0.1",
+      "source": "local",
+      "manifest_hash": "sha256:0b0a0819dbc8844c58c1b70e80a239fde74245658946b7298b4216597c6ee02f",
+      "enabled": true,
+      "priority": 10,
+      "registered_commands": {
+        "agy": [
+          "speckit.doc-sync.gate"
+        ],
+        "codex": [
+          "speckit.doc-sync.gate"
+        ],
+        "copilot": [
+          "speckit.doc-sync.gate"
+        ],
+        "zed": [
+          "speckit.doc-sync.gate"
+        ]
+      },
+      "registered_skills": [],
+      "installed_at": "2026-07-02T05:03:08.240888+00:00"
     }
   }
 }

--- a/.specify/extensions/doc-sync/.extensionignore
+++ b/.specify/extensions/doc-sync/.extensionignore
@@ -1,0 +1,3 @@
+# Development-only generated command surfaces.
+.specify-dev/
+

--- a/.specify/extensions/doc-sync/.specify-dev/agent-commands/agy/speckit-doc-sync-gate/SKILL.md
+++ b/.specify/extensions/doc-sync/.specify-dev/agent-commands/agy/speckit-doc-sync-gate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-doc-sync-gate
+description: Run the repository document/spec synchronization gate and report generated
+  traceability status.
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: doc-sync:commands/speckit.doc-sync.gate.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Run the canonical repository sync gate that keeps Spec Kit feature artifacts, SRS mappings, and generated traceability reports aligned.
+
+## Scope
+
+This command is intentionally narrow. It does not replace code-to-doc drift analysis or the third-party `speckit.sync.*` extension. It runs the repository-owned script:
+
+```powershell
+if (-not (Test-Path -LiteralPath ".\.venv\Scripts\Activate.ps1")) {
+  Write-Error "SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1"
+  exit 1
+}
+. .\.venv\Scripts\Activate.ps1
+python .\scripts\sync_spec_status.py --gate
+```
+
+The command regenerates:
+
+- `specs/spec-sync-status.md`
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`
+
+## Execution
+
+1. From the repository root, verify `.\.venv\Scripts\Activate.ps1` exists. If it is missing, report `SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1` and block.
+2. Activate the local virtual environment by dot-sourcing `. .\.venv\Scripts\Activate.ps1`.
+3. Run `python .\scripts\sync_spec_status.py --gate` in that activated environment.
+4. Treat any missing prerequisite or non-zero exit as blocking.
+5. If the script prints `SYNC GATE FAIL`, report each failure line exactly enough for the user to act on it.
+6. If the script prints `SYNC GATE PASS`, report that the document/spec sync gate passed and name both regenerated reports.
+7. Do not use cross-drive temporary output paths for this command on Windows; the script renders relative Markdown links and expects outputs on the repository drive.
+
+## Pass Criteria
+
+- `specs/spec-sync-status.md` is regenerated from `specs/spec-traceability.yaml`.
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md` is regenerated from the same manifest and SRS baseline.
+- Every mapped, gate-enforced feature reports sync status `current`.
+- No `SYNC GATE FAIL` lines are emitted.

--- a/.specify/extensions/doc-sync/.specify-dev/agent-commands/copilot/speckit.doc-sync.gate.agent.md
+++ b/.specify/extensions/doc-sync/.specify-dev/agent-commands/copilot/speckit.doc-sync.gate.agent.md
@@ -1,0 +1,52 @@
+---
+description: Run the repository document/spec synchronization gate and report generated
+  traceability status.
+---
+
+
+<!-- Extension: doc-sync -->
+<!-- Config: .specify/extensions/doc-sync/ -->
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Run the canonical repository sync gate that keeps Spec Kit feature artifacts, SRS mappings, and generated traceability reports aligned.
+
+## Scope
+
+This command is intentionally narrow. It does not replace code-to-doc drift analysis or the third-party `speckit.sync.*` extension. It runs the repository-owned script:
+
+```powershell
+if (-not (Test-Path -LiteralPath ".\.venv\Scripts\Activate.ps1")) {
+  Write-Error "SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1"
+  exit 1
+}
+. .\.venv\Scripts\Activate.ps1
+python .\scripts\sync_spec_status.py --gate
+```
+
+The command regenerates:
+
+- `specs/spec-sync-status.md`
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`
+
+## Execution
+
+1. From the repository root, verify `.\.venv\Scripts\Activate.ps1` exists. If it is missing, report `SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1` and block.
+2. Activate the local virtual environment by dot-sourcing `. .\.venv\Scripts\Activate.ps1`.
+3. Run `python .\scripts\sync_spec_status.py --gate` in that activated environment.
+4. Treat any missing prerequisite or non-zero exit as blocking.
+5. If the script prints `SYNC GATE FAIL`, report each failure line exactly enough for the user to act on it.
+6. If the script prints `SYNC GATE PASS`, report that the document/spec sync gate passed and name both regenerated reports.
+7. Do not use cross-drive temporary output paths for this command on Windows; the script renders relative Markdown links and expects outputs on the repository drive.
+
+## Pass Criteria
+
+- `specs/spec-sync-status.md` is regenerated from `specs/spec-traceability.yaml`.
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md` is regenerated from the same manifest and SRS baseline.
+- Every mapped, gate-enforced feature reports sync status `current`.
+- No `SYNC GATE FAIL` lines are emitted.

--- a/.specify/extensions/doc-sync/.specify-dev/agent-commands/zed/speckit-doc-sync-gate/SKILL.md
+++ b/.specify/extensions/doc-sync/.specify-dev/agent-commands/zed/speckit-doc-sync-gate/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: speckit-doc-sync-gate
+description: Run the repository document/spec synchronization gate and report generated
+  traceability status.
+compatibility: Requires spec-kit project structure with .specify/ directory
+metadata:
+  author: github-spec-kit
+  source: doc-sync:commands/speckit.doc-sync.gate.md
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Run the canonical repository sync gate that keeps Spec Kit feature artifacts, SRS mappings, and generated traceability reports aligned.
+
+## Scope
+
+This command is intentionally narrow. It does not replace code-to-doc drift analysis or the third-party `speckit.sync.*` extension. It runs the repository-owned script:
+
+```powershell
+if (-not (Test-Path -LiteralPath ".\.venv\Scripts\Activate.ps1")) {
+  Write-Error "SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1"
+  exit 1
+}
+. .\.venv\Scripts\Activate.ps1
+python .\scripts\sync_spec_status.py --gate
+```
+
+The command regenerates:
+
+- `specs/spec-sync-status.md`
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`
+
+## Execution
+
+1. From the repository root, verify `.\.venv\Scripts\Activate.ps1` exists. If it is missing, report `SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1` and block.
+2. Activate the local virtual environment by dot-sourcing `. .\.venv\Scripts\Activate.ps1`.
+3. Run `python .\scripts\sync_spec_status.py --gate` in that activated environment.
+4. Treat any missing prerequisite or non-zero exit as blocking.
+5. If the script prints `SYNC GATE FAIL`, report each failure line exactly enough for the user to act on it.
+6. If the script prints `SYNC GATE PASS`, report that the document/spec sync gate passed and name both regenerated reports.
+7. Do not use cross-drive temporary output paths for this command on Windows; the script renders relative Markdown links and expects outputs on the repository drive.
+
+## Pass Criteria
+
+- `specs/spec-sync-status.md` is regenerated from `specs/spec-traceability.yaml`.
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md` is regenerated from the same manifest and SRS baseline.
+- Every mapped, gate-enforced feature reports sync status `current`.
+- No `SYNC GATE FAIL` lines are emitted.

--- a/.specify/extensions/doc-sync/LICENSE
+++ b/.specify/extensions/doc-sync/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 dp-stock-investment-assistant
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/.specify/extensions/doc-sync/README.md
+++ b/.specify/extensions/doc-sync/README.md
@@ -1,0 +1,52 @@
+# Document Spec Sync Gate
+
+`doc-sync` is a repository-local Spec Kit extension that enforces synchronization between Spec Kit feature artifacts, the SRS mapping manifest, and generated traceability reports.
+
+## Purpose
+
+The extension provides one hard gate command:
+
+- `speckit.doc-sync.gate`
+
+The command activates the repository virtual environment and runs:
+
+```powershell
+python .\scripts\sync_spec_status.py --gate
+```
+
+The gate is canonical for this repository's forward and reverse SRS/spec reports. It does not replace optional code-to-doc drift analysis from third-party sync extensions.
+
+## Required Reports
+
+The command regenerates and gates:
+
+- `specs/spec-sync-status.md`
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`
+
+## Workflow Hooks
+
+This extension is configured as a hard gate at three lifecycle checkpoints:
+
+- `after_plan`: validate planned SRS mappings, baseline version, lifecycle status, and evidence paths before task generation.
+- `after_implement`: refresh reports from implementation evidence before verification.
+- `after_implement`, after `speckit.verify.run`: final closeout gate before a feature can be treated as `Verified`.
+
+## Prerequisites
+
+- Run from the repository root.
+- `.\.venv\Scripts\Activate.ps1` must exist.
+- `scripts\sync_spec_status.py` must exist.
+- `specs\spec-traceability.yaml` must be parseable.
+
+Missing prerequisites or any non-zero script exit are blocking failures.
+
+## Installation
+
+For local development, install from a copy of this extension directory:
+
+```powershell
+specify extension add <path-to-doc-sync-extension> --dev --force
+```
+
+The extension is already installed in this repository and registered through `.specify/extensions.yml`.
+

--- a/.specify/extensions/doc-sync/commands/speckit.doc-sync.gate.md
+++ b/.specify/extensions/doc-sync/commands/speckit.doc-sync.gate.md
@@ -1,0 +1,48 @@
+---
+description: "Run the repository document/spec synchronization gate and report generated traceability status."
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Goal
+
+Run the canonical repository sync gate that keeps Spec Kit feature artifacts, SRS mappings, and generated traceability reports aligned.
+
+## Scope
+
+This command is intentionally narrow. It does not replace code-to-doc drift analysis or the third-party `speckit.sync.*` extension. It runs the repository-owned script:
+
+```powershell
+if (-not (Test-Path -LiteralPath ".\.venv\Scripts\Activate.ps1")) {
+  Write-Error "SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1"
+  exit 1
+}
+. .\.venv\Scripts\Activate.ps1
+python .\scripts\sync_spec_status.py --gate
+```
+
+The command regenerates:
+
+- `specs/spec-sync-status.md`
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`
+
+## Execution
+
+1. From the repository root, verify `.\.venv\Scripts\Activate.ps1` exists. If it is missing, report `SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1` and block.
+2. Activate the local virtual environment by dot-sourcing `. .\.venv\Scripts\Activate.ps1`.
+3. Run `python .\scripts\sync_spec_status.py --gate` in that activated environment.
+4. Treat any missing prerequisite or non-zero exit as blocking.
+5. If the script prints `SYNC GATE FAIL`, report each failure line exactly enough for the user to act on it.
+6. If the script prints `SYNC GATE PASS`, report that the document/spec sync gate passed and name both regenerated reports.
+7. Do not use cross-drive temporary output paths for this command on Windows; the script renders relative Markdown links and expects outputs on the repository drive.
+
+## Pass Criteria
+
+- `specs/spec-sync-status.md` is regenerated from `specs/spec-traceability.yaml`.
+- `docs/domains/agent/SRS_SPEC_TRACEABILITY.md` is regenerated from the same manifest and SRS baseline.
+- Every mapped, gate-enforced feature reports sync status `current`.
+- No `SYNC GATE FAIL` lines are emitted.

--- a/.specify/extensions/doc-sync/extension.yml
+++ b/.specify/extensions/doc-sync/extension.yml
@@ -1,0 +1,51 @@
+schema_version: "1.0"
+
+extension:
+  id: "doc-sync"
+  name: "Document Spec Sync Gate"
+  version: "1.0.1"
+  description: "Hard SRS/spec sync gate for Spec Kit workflows."
+  author: "dp-stock-investment-assistant"
+  repository: "https://github.com/d-dragon/dp-stock-investment-assistant"
+  homepage: "https://github.com/d-dragon/dp-stock-investment-assistant/tree/main/.specify/extensions/doc-sync"
+  license: "MIT"
+
+requires:
+  speckit_version: ">=0.1.0"
+  commands:
+    - "speckit.plan"
+    - "speckit.implement"
+    - "speckit.verify.run"
+
+provides:
+  commands:
+    - name: "speckit.doc-sync.gate"
+      file: "commands/speckit.doc-sync.gate.md"
+      description: "Run the canonical document/spec synchronization gate and report regenerated traceability outputs"
+
+hooks:
+  after_plan:
+    command: "speckit.doc-sync.gate"
+    priority: 10
+    optional: false
+    prompt: "Run document-spec sync gate after planning?"
+    description: "Validate planned SRS mappings and sync reports before task generation"
+
+  after_implement:
+    - command: "speckit.doc-sync.gate"
+      priority: 5
+      optional: false
+      prompt: "Run implementation document-spec sync gate before verification?"
+      description: "Refresh traceability reports from implementation evidence before verification"
+    - command: "speckit.doc-sync.gate"
+      priority: 50
+      optional: false
+      prompt: "Run final document-spec sync gate after verification?"
+      description: "Final hard sync gate before treating a feature as Verified"
+
+tags:
+  - "governance"
+  - "traceability"
+  - "srs"
+  - "sync"
+  - "quality-gate"

--- a/.specify/workflows/speckit/workflow.yml
+++ b/.specify/workflows/speckit/workflow.yml
@@ -50,6 +50,17 @@ steps:
     options: [approve, reject]
     on_reject: abort
 
+  - id: sync-after-plan
+    type: shell
+    command: >-
+      powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path -LiteralPath '.\.venv\Scripts\Activate.ps1')) { Write-Error 'SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1'; exit 1 }; . .\.venv\Scripts\Activate.ps1; python .\scripts\sync_spec_status.py --gate"
+
+  - id: review-sync-after-plan
+    type: gate
+    message: "Review regenerated specs/spec-sync-status.md and docs/domains/agent/SRS_SPEC_TRACEABILITY.md before generating tasks."
+    options: [approve, reject]
+    on_reject: abort
+
   - id: tasks
     command: speckit.tasks
     integration: "{{ inputs.integration }}"
@@ -61,3 +72,37 @@ steps:
     integration: "{{ inputs.integration }}"
     input:
       args: "{{ inputs.spec }}"
+
+  - id: sync-after-implement
+    type: shell
+    command: >-
+      powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path -LiteralPath '.\.venv\Scripts\Activate.ps1')) { Write-Error 'SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1'; exit 1 }; . .\.venv\Scripts\Activate.ps1; python .\scripts\sync_spec_status.py --gate"
+
+  - id: review-sync-after-implement
+    type: gate
+    message: "Review implementation-time sync reports before verification."
+    options: [approve, reject]
+    on_reject: abort
+
+  - id: verify-tasks
+    command: speckit.verify-tasks.run
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: verify
+    command: speckit.verify.run
+    integration: "{{ inputs.integration }}"
+    input:
+      args: "{{ inputs.spec }}"
+
+  - id: sync-after-verify
+    type: shell
+    command: >-
+      powershell -NoProfile -ExecutionPolicy Bypass -Command "if (-not (Test-Path -LiteralPath '.\.venv\Scripts\Activate.ps1')) { Write-Error 'SYNC GATE FAIL: missing .venv\Scripts\Activate.ps1'; exit 1 }; . .\.venv\Scripts\Activate.ps1; python .\scripts\sync_spec_status.py --gate"
+
+  - id: review-sync-after-verify
+    type: gate
+    message: "Review final sync reports before treating the feature as Verified."
+    options: [approve, reject]
+    on_reject: abort

--- a/docs/spec-driven development (SDD)/spec-kit HOW-TO.md
+++ b/docs/spec-driven development (SDD)/spec-kit HOW-TO.md
@@ -112,7 +112,8 @@ As of 2026-07-01, this repository should be operated from the local installed tr
 | Integration status | `specify integration status` currently exits non-zero because Copilot + Codex is a forced multi-install and Copilot is not declared multi-install safe upstream | Treat `unsafe-multi-install` as a known portability warning only when no managed files are missing or invalid. Missing manifests, invalid manifests, or unexpected default changes remain blockers. |
 | Workflow catalog | `specify workflow info speckit` reports the six-step bundled workflow: specify, review-spec, plan, review-plan, tasks, implement | This repository's 18-step SDLC is a governance overlay around the bundled workflow, not a replacement for the local prompt/skill commands. |
 | Installed extensions | Understanding, Verify Tasks, Spec Kit Utilities, Git, Fleet, Verify, Memory Loader, Architecture Workflow, Coding Agent Context, Research Harness, Security Review, and Architecture Guard are enabled | Use current extension command names from this HOW-TO instead of older shorthand names. |
-| Sync extension | A sync extension package may exist in `.specify/extensions/sync`, but `speckit.sync.*` is not installed/enabled in the current command surface | Use `python scripts/sync_spec_status.py --gate` for supported sync reporting until a governed extension install adopts `speckit.sync.*`. |
+| Document/spec sync gate | `speckit.doc-sync.gate` is the repository-local wrapper around `python scripts/sync_spec_status.py --gate` | Run this hard gate after `speckit.plan`, after `speckit.implement`, and after `speckit.verify.run`; it regenerates `specs/spec-sync-status.md` and `docs/domains/agent/SRS_SPEC_TRACEABILITY.md`. |
+| Third-party sync extension | A sync extension package may exist in `.specify/extensions/sync`, but `speckit.sync.*` is not installed/enabled in the current command surface | Treat it as optional drift-analysis support only until a governed migration proves it covers this repository's generated SRS/spec reports. |
 
 ### 2.4 Install or Recreate Local CLI Access
 
@@ -660,6 +661,8 @@ The 18-step lifecycle below is the detailed execution model inside the SDLC loop
     - **Cross-Reference Prompt Hint**:
       > *Prompt Hint*: "Run verification: 'Verify implementation compliance with [constitution.md](../../.specify/memory/constitution.md) principles and confirm test results conform to evidence policies in [VERIFICATION_AND_TRACEABILITY_STRATEGY.md](../testing/VERIFICATION_AND_TRACEABILITY_STRATEGY.md).'"
 
+**Document-Spec Sync Gates**: Run `speckit.doc-sync.gate` at three hard checkpoints around delivery. After `speckit.plan`, the gate validates planned SRS mappings, baseline version, lifecycle status, and evidence paths before task generation. After `speckit.implement`, it refreshes forward and reverse reports from implementation evidence before verification. After `speckit.verify.run`, it is the final closeout gate before a feature can be treated as `Verified`. The command surface is `speckit.doc-sync.gate`, and the canonical executable operation remains `python scripts/sync_spec_status.py --gate`.
+
 #### 3.3.5 Synchronization and Maintenance
 
 15. **Test and Traceability Refresh**: Run project test suites and update [spec-traceability.yaml](../../specs/spec-traceability.yaml) whenever delivered scope changes.
@@ -668,7 +671,7 @@ The 18-step lifecycle below is the detailed execution model inside the SDLC loop
       - [spec-sync-status.md](../../specs/spec-sync-status.md)
       - [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md)
     - **Cross-Reference Prompt Hint**:
-      > *Prompt Hint*: "Refresh traceability manifests: 'Execute the project's test suite and compile evidence links. Update [spec-traceability.yaml](../../specs/spec-traceability.yaml) status to `verified` and update [spec-sync-status.md](../../specs/spec-sync-status.md) coverage metrics.'"
+      > *Prompt Hint*: "Refresh traceability manifests: 'Execute the project's test suite and compile evidence links. Update [spec-traceability.yaml](../../specs/spec-traceability.yaml) status to `verified`, then run `python scripts/sync_spec_status.py --gate` to regenerate [spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md).'"
 
 16. **Maintenance Update**: Keep governed feature artifacts current after delivery, including plan, review, status, and operational notes when behavior evolves.
     - **Mapped Long-Lived Documents**:
@@ -784,7 +787,7 @@ flowchart TB
   class BS,AS,BP,AP,BT,AT,BI,AI,L_Hook hook;
 ```
 
-In this repository, the hook sequence usually covers branch setup, memory loading, `doctor`, `validate`, fleet review, verification, and architecture review around the core `specify`, `plan`, `tasks`, and `implement` commands.
+In this repository, the hook sequence usually covers branch setup, memory loading, `doctor`, `validate`, required document/spec sync gates, fleet review, verification, and architecture review around the core `specify`, `plan`, `tasks`, and `implement` commands. The required sync gates run after `speckit.plan`, after `speckit.implement`, and after `speckit.verify.run`.
 
 #### 3.4.3 Artifact Flow and Synchronization
 
@@ -858,8 +861,8 @@ The repository still contains older lifecycle terminology in some places. Use th
 | `speckit.review` | typically handled as `speckit.fleet.review` in this repository |
 | `speckit.verify` | `speckit.verify.run` |
 | `speckit.verify-tasks` | `speckit.verify-tasks.run` |
-| `speckit.sync` or `speckit.sync.analyze` | not installed/enabled today; use `python scripts/sync_spec_status.py --gate` plus manual or skill-assisted doc promotion |
-| `speckit.converge` | official upstream convergence concept, upgrade-gated here until the CLI and local managed prompts/skills expose it; current closeout is `speckit.verify-tasks.run`, `speckit.verify.run`, sync gate, and documentation promotion |
+| `speckit.sync` or `speckit.sync.analyze` | not installed/enabled today; use `speckit.doc-sync.gate` / `python scripts/sync_spec_status.py --gate` plus manual or skill-assisted doc promotion |
+| `speckit.converge` | official upstream convergence concept, upgrade-gated here until the CLI and local managed prompts/skills expose it; current closeout is `speckit.verify-tasks.run`, `speckit.verify.run`, final document/spec sync gate, and documentation promotion |
 | `speckit.tests` | repository test execution plus traceability refresh, not a single core Spec Kit command |
 | `speckit.maintain` | maintenance stage name, not a single installed core command |
 
@@ -873,15 +876,15 @@ Use the status names below in feature `spec.md` headers, reviews, traceability n
 | `Clarified` | Major ambiguity has been resolved and the spec is ready for planning | `spec.md` records clarification decisions; no blocking `NEEDS CLARIFICATION` remains for the approved scope. |
 | `Planned` | Implementation approach is accepted but delivery is not complete | `plan.md` exists and constitution/technical context checks are recorded. |
 | `Implemented` | Tasks are complete and implementation evidence exists, but final verification marker is not present | `tasks.md` is complete; implementation, review, or verify-task evidence exists; `.verify-done` may be absent. |
-| `Verified` | Implementation has passed the post-implementation gate | `review.md` exists, `.verify-done` exists, task completion is complete, and the sync gate reports `current`. |
+| `Verified` | Implementation has passed the post-implementation gate | `review.md` exists, `.verify-done` exists, task completion is complete, and the final after-verify sync gate reports `current`. |
 | `Backfilled` | Spec was created after existing behavior to restore governance coverage | The spec names the source implementation evidence and must be reconciled through analysis and sync before it becomes normal planned/implemented work. |
 | `Superseded` | Feature directory is retained for history but replaced by another spec or governed artifact | `spec.md` links the replacement and explains whether traceability moved or remains historical. |
 
 Status movement rules:
 
 - Update the `**Status**` field in `spec.md` when the feature moves between these lifecycle states.
-- Create or update `review.md` during implementation verification; create `.verify-done` only after the post-implementation verification gate passes.
-- Regenerate [spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) with `python scripts/sync_spec_status.py --gate` after status, tasks, review, or SRS mapping changes.
+- Create or update `review.md` during implementation verification; create `.verify-done` only after `speckit.verify.run` passes.
+- Regenerate [spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) with `speckit.doc-sync.gate` / `python scripts/sync_spec_status.py --gate` after planning, implementation, verification, status, tasks, review, or SRS mapping changes.
 - Use `Implemented`, not `Verified`, when implementation evidence is complete but `.verify-done` is absent.
 - Use `Backfilled` for governance restoration of pre-existing behavior; do not use it for a normal feature that is merely late in updating docs.
 
@@ -941,21 +944,21 @@ The repository's configured extension hooks form an operating overlay around the
 | Before `specify` | feature branch creation, memory loading | Prepare a clean feature context |
 | After `specify` | doctor, optional commit | Check project health and preserve generated state |
 | Before `plan` | optional commit, memory loading | Carry forward clean context into planning |
-| After `plan` | validate, architecture scan | Check traceability and detect drift early |
+| After `plan` | validate, document/spec sync gate, architecture scan | Check planned SRS mappings, lifecycle status, evidence paths, and drift before task generation |
 | Before `tasks` | optional commit, memory loading | Keep task generation grounded in current state |
 | After `tasks` | requirements validation, fleet review, architecture follow-up | Strengthen readiness before implementation |
 | Before `implement` | optional commit, memory loading | Reduce context loss before code generation |
-| After `implement` | verify-tasks.run, verify.run, architecture review | Confirm real delivery and post-implementation compliance |
+| After `implement` | document/spec sync gate, verify-tasks.run, verify.run, final document/spec sync gate, architecture review | Confirm real delivery, verification evidence, generated reports, and post-implementation compliance |
 
 When documenting or adjusting this automation, prefer what is actually configured in [../../.specify/extensions.yml](../../.specify/extensions.yml) over generic examples from older Spec Kit material.
 
-The current supported synchronization posture is local-script first: regenerate forward and reverse traceability with `python scripts/sync_spec_status.py --gate`. Do not document `speckit.sync.*` as an available command surface until `specify extension list` shows the sync extension installed and enabled.
+The current supported synchronization posture is local-script first: `speckit.doc-sync.gate` runs `python scripts/sync_spec_status.py --gate` to regenerate forward and reverse traceability. Do not document third-party `speckit.sync.*` as the canonical sync surface until a governed migration shows the extension installed, enabled, and capable of producing this repository's SRS/spec reports.
 
 ## 6. Best Practices
 
 - Create and maintain governed feature artifacts under [../../specs/](../../specs/), not under `docs/` and not as the primary record in `.specify/specs/`.
 - Keep [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml) synchronized whenever SRS scope changes.
-- Keep [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) aligned with actual feature status and evidence by running `python scripts/sync_spec_status.py --gate` after traceability, status, or review changes.
+- Keep [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) aligned with actual feature status and evidence by running `speckit.doc-sync.gate` / `python scripts/sync_spec_status.py --gate` after planning, implementation, verification, traceability, status, or review changes.
 - Treat the project constitution in [../../.specify/memory/constitution.md](../../.specify/memory/constitution.md) as binding when reviewing or implementing work.
 - Use [../../docs/openapi.yaml](../../docs/openapi.yaml) as a mandatory synchronization target for REST API changes.
 - Prefer current official documentation links from `https://github.github.io/spec-kit/` over older repository blob links.
@@ -968,7 +971,7 @@ The current supported synchronization posture is local-script first: regenerate 
 - **A command does not appear in the agent**: run `specify extension list`, confirm the related extension is available locally, and review [../../.specify/extensions.yml](../../.specify/extensions.yml).
 - **The integration looks wrong**: run `specify integration status` and `specify integration list`; this repository expects GitHub Copilot as default, Codex as an installed secondary integration, and PowerShell-oriented scripts.
 - **Unsure where to place new feature artifacts**: publish governed work in [../../specs/](../../specs/). Treat `.specify/` as supporting automation and template infrastructure.
-- **Traceability is stale**: update [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml), refresh task and review evidence, then run `python scripts/sync_spec_status.py --gate` to bring [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) back in line.
+- **Traceability is stale**: update [../../specs/spec-traceability.yaml](../../specs/spec-traceability.yaml), refresh planning, task, implementation, and review evidence as appropriate, then run `speckit.doc-sync.gate` / `python scripts/sync_spec_status.py --gate` to bring [../../specs/spec-sync-status.md](../../specs/spec-sync-status.md) and [SRS_SPEC_TRACEABILITY.md](../domains/agent/SRS_SPEC_TRACEABILITY.md) back in line.
 - **REST behavior changed but documentation did not**: update [../../docs/openapi.yaml](../../docs/openapi.yaml) as part of the same delivery cycle.
 - **Mermaid does not render cleanly**: keep diagrams in fenced `mermaid` blocks and use short labels with simple punctuation.
 


### PR DESCRIPTION
## Summary
- Add a new `doc-sync` extension that exposes `speckit.doc-sync.gate` as the repository-local document/spec sync gate
- Register the command surfaces for Copilot, Codex, AgY, and Zed, plus the extension manifest and registry entries
- Wire the sync gate into Spec Kit lifecycle hooks and workflow steps after planning, after implementation, and after verification
- Update the Spec Kit HOW-TO to describe the new hard gate and its generated traceability reports

## Testing
- Not run (not requested)